### PR TITLE
Add comprehensive unit and integration tests

### DIFF
--- a/server/sensor_data_reciver/app.py
+++ b/server/sensor_data_reciver/app.py
@@ -9,14 +9,13 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Optional, Tuple
 
+import influxdb_client
 import serial
 import serial_asyncio
 from dotenv import load_dotenv
-from PIL import Image
-
-import influxdb_client
 from influxdb_client import Point
 from influxdb_client.client.write_api import SYNCHRONOUS
+from PIL import Image
 
 load_dotenv()
 

--- a/server/sensor_data_reciver/pyproject.toml
+++ b/server/sensor_data_reciver/pyproject.toml
@@ -24,4 +24,12 @@ exclude = [
 [dependency-groups]
 dev = [
     "just-bin>=1.40.0",
+    "pytest>=8.0.0",
+    "pytest-cov>=6.1.1",
+    "pytest-asyncio>=0.23.0",
 ]
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]
+addopts = "-v"

--- a/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
+++ b/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
@@ -1,0 +1,178 @@
+import asyncio
+import os
+import shutil
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+# テストファイルから見た app.py への正しいパス
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from app import (CHECKSUM_LENGTH, END_MARKER, FRAME_TYPE_DATA, FRAME_TYPE_EOF,
+                 FRAME_TYPE_HASH, LENGTH_FIELD_BYTES, SEQUENCE_NUM_LENGTH,
+                 START_MARKER, SerialProtocol, config, image_receiver)
+
+
+@pytest_asyncio.fixture
+async def setup_test_environment():
+    """テスト環境のセットアップ"""
+    # テスト用に設定を調整
+    original_config = {
+        'MAX_BUFFER_SIZE': getattr(config, 'MAX_BUFFER_SIZE', None),
+        'IMAGE_TIMEOUT': getattr(config, 'IMAGE_TIMEOUT', None),
+        'IMAGE_DIR': getattr(config, 'IMAGE_DIR', None)
+    }
+    
+    config.MAX_BUFFER_SIZE = 1024  # 1KB
+    config.IMAGE_TIMEOUT = 1  # 1秒
+    config.IMAGE_DIR = "test_images"  # テスト用ディレクトリ
+    
+    # グローバル状態をクリア
+    image_receiver.image_buffers.clear()
+    image_receiver.last_receive_time.clear()
+    image_receiver.stats = {"received_images": 0, "total_bytes": 0, "start_time": time.time()}
+    
+    # テスト用ディレクトリの作成
+    os.makedirs(config.IMAGE_DIR, exist_ok=True)
+    
+    yield
+    
+    # クリーンアップ
+    await image_receiver.cleanup_resources()
+    # テスト用ディレクトリの削除
+    shutil.rmtree(config.IMAGE_DIR, ignore_errors=True)
+    
+    # 設定を元に戻す
+    for key, value in original_config.items():
+        if value is not None:
+            setattr(config, key, value)
+
+
+@patch('app.write_api')  # write_apiを直接パッチ
+@patch('app.serial_asyncio.create_serial_connection')
+@patch('app.influxdb_client.InfluxDBClient')
+@patch('app.Image')  # PIL Imageもモック化
+@patch('app.save_image')  # save_image関数もモック化
+class TestSerialProtocolIntegration:
+
+    @pytest.mark.asyncio
+    async def test_receive_hash_frame(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_api, setup_test_environment):
+        # モックオブジェクトの準備
+        mock_transport = MagicMock()
+        mock_protocol = MagicMock()
+        mock_transport.serial = MagicMock(port="test_port")  # serialオブジェクトを設定
+
+        mock_serial_connection.return_value = (mock_transport, mock_protocol)
+
+        # HASHフレームの作成
+        mac_bytes = b"\x01\x02\x03\x04\x05\x06"
+        sender_mac = "01:02:03:04:05:06"
+        seq_num = 1
+        payload_str = "HASH:abcdef123456,VOLT:12.3,TEMP:25.5,1678886400"  # タイムスタンプはdummyでOK
+        payload_bytes = payload_str.encode('ascii')
+        data_len = len(payload_bytes)
+        
+        frame_bytes = (
+            START_MARKER +
+            mac_bytes +
+            bytes([FRAME_TYPE_HASH]) +
+            seq_num.to_bytes(SEQUENCE_NUM_LENGTH, byteorder="big") +
+            data_len.to_bytes(LENGTH_FIELD_BYTES, byteorder="big") +
+            payload_bytes +
+            b'\x00' * CHECKSUM_LENGTH +  # チェックサムはdummyでOK
+            END_MARKER
+        )
+
+        # プロトコルインスタンス作成
+        loop = asyncio.get_running_loop()
+        connection_lost_future = loop.create_future()
+        protocol = SerialProtocol(connection_lost_future)
+        protocol.connection_made(mock_transport)
+
+        # データ受信
+        protocol.data_received(frame_bytes)
+
+        # InfluxDBへの書き込みが呼ばれたか確認
+        mock_write_api.write.assert_called_once()
+        args, kwargs = mock_write_api.write.call_args
+        record = kwargs['record']
+        assert record._name == 'data'  # measurementの内部アクセス
+        assert record._tags['mac_address'] == sender_mac
+        assert record._fields['voltage'] == 12.3
+        assert record._fields['temperature'] == 25.5
+
+    @pytest.mark.asyncio
+    async def test_receive_data_and_eof_frames(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_api, setup_test_environment):
+        # モックオブジェクトの準備
+        mock_transport = MagicMock()
+        mock_protocol = MagicMock()
+        mock_transport.serial = MagicMock(port="test_port")
+        mock_serial_connection.return_value = (mock_transport, mock_protocol)
+
+        # データフレームの作成
+        mac_bytes = b"\x01\x02\x03\x04\x05\x06"
+        sender_mac = "01:02:03:04:05:06"
+        seq_num_data = 1
+        data_chunk_1 = b'\x00' * 500
+        data_len_1 = len(data_chunk_1)
+        frame_data_1 = (
+            START_MARKER +
+            mac_bytes +
+            bytes([FRAME_TYPE_DATA]) +
+            seq_num_data.to_bytes(SEQUENCE_NUM_LENGTH, byteorder="big") +
+            data_len_1.to_bytes(LENGTH_FIELD_BYTES, byteorder="big") +
+            data_chunk_1 +
+            b'\x00' * CHECKSUM_LENGTH +
+            END_MARKER
+        )
+
+        data_chunk_2 = b'\x01' * 400
+        data_len_2 = len(data_chunk_2)
+        frame_data_2 = (
+            START_MARKER +
+            mac_bytes +
+            bytes([FRAME_TYPE_DATA]) +
+            (seq_num_data + 1).to_bytes(SEQUENCE_NUM_LENGTH, byteorder="big") +  # シーケンス番号は連続でなくても良い
+            data_len_2.to_bytes(LENGTH_FIELD_BYTES, byteorder="big") +
+            data_chunk_2 +
+            b'\x00' * CHECKSUM_LENGTH +
+            END_MARKER
+        )
+
+        # EOFフレームの作成
+        seq_num_eof = 2  # EOFフレームのデータ長は0
+        data_len_eof = 0
+        frame_eof = (
+            START_MARKER +
+            mac_bytes +
+            bytes([FRAME_TYPE_EOF]) +
+            seq_num_eof.to_bytes(SEQUENCE_NUM_LENGTH, byteorder="big") +
+            data_len_eof.to_bytes(LENGTH_FIELD_BYTES, byteorder="big") +
+            b'' +  # データなし
+            b'\x00' * CHECKSUM_LENGTH +
+            END_MARKER
+        )
+        
+        # プロトコルインスタンス作成
+        loop = asyncio.get_running_loop()
+        connection_lost_future = loop.create_future()
+        protocol = SerialProtocol(connection_lost_future)
+        protocol.connection_made(mock_transport)
+
+        # データ受信
+        protocol.data_received(frame_data_1)
+        protocol.data_received(frame_data_2)
+        protocol.data_received(frame_eof)
+
+        # save_image関数が呼ばれたか確認
+        mock_save_image.assert_called_once()
+        args, _ = mock_save_image.call_args
+        assert args[0] == sender_mac
+        assert args[1] == data_chunk_1 + data_chunk_2
+        
+        # バッファがクリアされたか確認
+        assert sender_mac not in image_receiver.image_buffers
+        assert sender_mac not in image_receiver.last_receive_time

--- a/server/sensor_data_reciver/tests/unit/test_frame_parser.py
+++ b/server/sensor_data_reciver/tests/unit/test_frame_parser.py
@@ -1,0 +1,72 @@
+import os
+import sys
+
+import pytest
+
+# テストファイルから見た app.py への正しいパス
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from app import (CHECKSUM_LENGTH, END_MARKER, FRAME_TYPE_DATA, FRAME_TYPE_EOF,
+                 FRAME_TYPE_HASH, FRAME_TYPE_LENGTH, LENGTH_FIELD_BYTES,
+                 MAC_ADDRESS_LENGTH, SEQUENCE_NUM_LENGTH, START_MARKER,
+                 FrameParser)
+
+
+def test_parse_header_valid():
+    mac_bytes = b"\x01\x02\x03\x04\x05\x06"
+    sender_mac = "01:02:03:04:05:06"
+    frame_type = FRAME_TYPE_DATA
+    seq_num = 1234
+    data_len = 500
+
+    header_bytes = (
+        START_MARKER +
+        mac_bytes +
+        bytes([frame_type]) +
+        seq_num.to_bytes(SEQUENCE_NUM_LENGTH, byteorder="big") +
+        data_len.to_bytes(LENGTH_FIELD_BYTES, byteorder="big")
+    )
+
+    parsed_mac, parsed_type, parsed_seq, parsed_len = FrameParser.parse_header(header_bytes, 0)
+
+    assert parsed_mac == sender_mac
+    assert parsed_type == frame_type
+    assert parsed_seq == seq_num
+    assert parsed_len == data_len
+
+def test_parse_header_invalid_mac_length():
+    mac_bytes = b"\x01\x02\x03\x04\x05"  # Too short
+    data_len = 500
+
+    # parse_headerではなく、validate_frame_dataでエラーが発生するはず
+    with pytest.raises(ValueError):
+        FrameParser.validate_frame_data(data_len, mac_bytes)
+
+def test_validate_frame_data_valid():
+    mac_bytes = b"\x01\x02\x03\x04\x05\x06"
+    data_len = 500
+    assert FrameParser.validate_frame_data(data_len, mac_bytes) is True
+
+def test_validate_frame_data_too_long_data():
+    mac_bytes = b"\x01\x02\x03\x04\x05\x06"
+    data_len = 1000 # Assuming MAX_DATA_LEN is 512
+    with pytest.raises(ValueError):
+        FrameParser.validate_frame_data(data_len, mac_bytes)
+
+def test_validate_frame_data_invalid_mac_length():
+    mac_bytes = b"\x01\x02\x03\x04\x05"
+    data_len = 500
+    with pytest.raises(ValueError):
+        FrameParser.validate_frame_data(data_len, mac_bytes)
+
+def test_sanitize_filename_basic():
+    mac_str = "01:02:03:04:05:06"
+    timestamp = "20231027_103000_123456"
+    expected_filename = "010203040506_20231027_103000_123456.jpg"
+    assert FrameParser.sanitize_filename(mac_str, timestamp) == expected_filename
+
+def test_sanitize_filename_special_chars():
+    mac_str = "01:02-03:04-05:06"
+    timestamp = "2023/10/27_10:30:00_123456"
+    expected_filename = "0102-0304-0506_20231027_103000_123456.jpg"
+    assert FrameParser.sanitize_filename(mac_str, timestamp) == expected_filename

--- a/server/sensor_data_reciver/tests/unit/test_image_receiver.py
+++ b/server/sensor_data_reciver/tests/unit/test_image_receiver.py
@@ -1,0 +1,83 @@
+import asyncio
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+
+# テストファイルから見た app.py への正しいパス
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from app import ImageReceiver, config, save_image
+
+
+@pytest_asyncio.fixture
+async def receiver_instance():
+    receiver = ImageReceiver()
+    # テスト用に設定を調整してメモリテストを容易にする
+    config.MAX_BUFFER_SIZE = 1024 # 1KB
+    config.IMAGE_TIMEOUT = 1 # 1秒
+    yield receiver
+    await receiver.cleanup_resources()
+
+@pytest.mark.asyncio
+async def test_check_memory_usage_ok(receiver_instance):
+    mac1 = "01:02:03:04:05:06"
+    mac2 = "07:08:09:0a:0b:0c"
+    receiver_instance.image_buffers[mac1] = bytearray(b'a' * 500)
+    receiver_instance.image_buffers[mac2] = bytearray(b'b' * 400)
+    receiver_instance.last_receive_time[mac1] = time.monotonic()
+    receiver_instance.last_receive_time[mac2] = time.monotonic()
+
+    receiver_instance.check_memory_usage()
+
+    assert len(receiver_instance.image_buffers) == 2
+
+@pytest.mark.asyncio
+async def test_check_memory_usage_cleanup(receiver_instance):
+    mac1 = "01:02:03:04:05:06"
+    mac2 = "07:08:09:0a:0b:0c"
+    receiver_instance.image_buffers[mac1] = bytearray(b'a' * 600)
+    receiver_instance.image_buffers[mac2] = bytearray(b'b' * 600)
+    receiver_instance.last_receive_time[mac1] = time.monotonic()
+    receiver_instance.last_receive_time[mac2] = time.monotonic() - 10 # mac2が古い
+
+    receiver_instance.check_memory_usage()
+
+    assert len(receiver_instance.image_buffers) == 1
+    assert mac1 in receiver_instance.image_buffers
+    assert mac2 not in receiver_instance.image_buffers
+
+@pytest.mark.asyncio
+async def test_cleanup_buffer(receiver_instance):
+    mac1 = "01:02:03:04:05:06"
+    mac2 = "07:08:09:0a:0b:0c"
+    receiver_instance.image_buffers[mac1] = bytearray(b'a' * 100)
+    receiver_instance.image_buffers[mac2] = bytearray(b'b' * 100)
+    receiver_instance.last_receive_time[mac1] = time.monotonic()
+    receiver_instance.last_receive_time[mac2] = time.monotonic()
+
+    receiver_instance._cleanup_buffer(mac1)
+
+    assert mac1 not in receiver_instance.image_buffers
+    assert mac1 not in receiver_instance.last_receive_time
+    assert mac2 in receiver_instance.image_buffers
+    assert mac2 in receiver_instance.last_receive_time
+
+@patch('app.write_file_sync')
+@pytest.mark.asyncio
+async def test_save_image(mock_write_file_sync):
+    mac_str = "01:02:03:04:05:06"
+    image_data = b'\x00' * 1024
+    
+    await save_image(mac_str, image_data)
+
+    mock_write_file_sync.assert_called_once()
+    args, _ = mock_write_file_sync.call_args
+    filename = args[0]
+    assert args[1] == image_data
+    # ファイル名に関する基本的なチェックを追加
+    assert mac_str.replace(':', '') in filename
+    assert filename.endswith(".jpg")

--- a/server/sensor_data_reciver/tests/unit/test_voltage_data_processor.py
+++ b/server/sensor_data_reciver/tests/unit/test_voltage_data_processor.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import pytest
+
+# テストファイルから見た app.py への正しいパス
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from app import VoltageDataProcessor
+
+
+def test_parse_voltage_data_valid():
+    payload = "TEMP:25.5,VOLT:12.3,OTHER:data"
+    voltage = VoltageDataProcessor.parse_voltage_data(payload)
+    assert voltage == 12.3
+
+def test_parse_voltage_data_not_found():
+    payload = "TEMP:25.5,OTHER:data"
+    voltage = VoltageDataProcessor.parse_voltage_data(payload)
+    assert voltage is None
+
+def test_parse_voltage_data_invalid_format():
+    payload = "TEMP:25.5,VOLT:abc,OTHER:data"
+    voltage = VoltageDataProcessor.parse_voltage_data(payload)
+    assert voltage is None
+
+def test_parse_temperature_data_valid():
+    payload = "TEMP:25.5,VOLT:12.3,OTHER:data"
+    temperature = VoltageDataProcessor.parse_temperature_data(payload)
+    assert temperature == 25.5
+
+def test_parse_temperature_data_not_found():
+    payload = "VOLT:12.3,OTHER:data"
+    temperature = VoltageDataProcessor.parse_temperature_data(payload)
+    assert temperature is None
+
+def test_parse_temperature_data_invalid_format():
+    payload = "TEMP:xyz,VOLT:12.3,OTHER:data"
+    temperature = VoltageDataProcessor.parse_temperature_data(payload)
+    assert temperature is None

--- a/server/sensor_data_reciver/uv.lock
+++ b/server/sensor_data_reciver/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -9,6 +8,74 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "coverage"
+version = "7.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/07/998afa4a0ecdf9b1981ae05415dad2d4e7716e1b1f00abbd91691ac09ac9/coverage-7.8.2.tar.gz", hash = "sha256:a886d531373a1f6ff9fad2a2ba4a045b68467b779ae729ee0b3b10ac20033b27", size = 812759 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/4d/1ff618ee9f134d0de5cc1661582c21a65e06823f41caf801aadf18811a8e/coverage-7.8.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b99058eef42e6a8dcd135afb068b3d53aff3921ce699e127602efff9956457a9", size = 211692 },
+    { url = "https://files.pythonhosted.org/packages/96/fa/c3c1b476de96f2bc7a8ca01a9f1fcb51c01c6b60a9d2c3e66194b2bdb4af/coverage-7.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5feb7f2c3e6ea94d3b877def0270dff0947b8d8c04cfa34a17be0a4dc1836879", size = 212115 },
+    { url = "https://files.pythonhosted.org/packages/f7/c2/5414c5a1b286c0f3881ae5adb49be1854ac5b7e99011501f81c8c1453065/coverage-7.8.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:670a13249b957bb9050fab12d86acef7bf8f6a879b9d1a883799276e0d4c674a", size = 244740 },
+    { url = "https://files.pythonhosted.org/packages/cd/46/1ae01912dfb06a642ef3dd9cf38ed4996fda8fe884dab8952da616f81a2b/coverage-7.8.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0bdc8bf760459a4a4187b452213e04d039990211f98644c7292adf1e471162b5", size = 242429 },
+    { url = "https://files.pythonhosted.org/packages/06/58/38c676aec594bfe2a87c7683942e5a30224791d8df99bcc8439fde140377/coverage-7.8.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:07a989c867986c2a75f158f03fdb413128aad29aca9d4dbce5fc755672d96f11", size = 244218 },
+    { url = "https://files.pythonhosted.org/packages/80/0c/95b1023e881ce45006d9abc250f76c6cdab7134a1c182d9713878dfefcb2/coverage-7.8.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2db10dedeb619a771ef0e2949ccba7b75e33905de959c2643a4607bef2f3fb3a", size = 243865 },
+    { url = "https://files.pythonhosted.org/packages/57/37/0ae95989285a39e0839c959fe854a3ae46c06610439350d1ab860bf020ac/coverage-7.8.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e6ea7dba4e92926b7b5f0990634b78ea02f208d04af520c73a7c876d5a8d36cb", size = 242038 },
+    { url = "https://files.pythonhosted.org/packages/4d/82/40e55f7c0eb5e97cc62cbd9d0746fd24e8caf57be5a408b87529416e0c70/coverage-7.8.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ef2f22795a7aca99fc3c84393a55a53dd18ab8c93fb431004e4d8f0774150f54", size = 242567 },
+    { url = "https://files.pythonhosted.org/packages/f9/35/66a51adc273433a253989f0d9cc7aa6bcdb4855382cf0858200afe578861/coverage-7.8.2-cp311-cp311-win32.whl", hash = "sha256:641988828bc18a6368fe72355df5f1703e44411adbe49bba5644b941ce6f2e3a", size = 214194 },
+    { url = "https://files.pythonhosted.org/packages/f6/8f/a543121f9f5f150eae092b08428cb4e6b6d2d134152c3357b77659d2a605/coverage-7.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:8ab4a51cb39dc1933ba627e0875046d150e88478dbe22ce145a68393e9652975", size = 215109 },
+    { url = "https://files.pythonhosted.org/packages/77/65/6cc84b68d4f35186463cd7ab1da1169e9abb59870c0f6a57ea6aba95f861/coverage-7.8.2-cp311-cp311-win_arm64.whl", hash = "sha256:8966a821e2083c74d88cca5b7dcccc0a3a888a596a04c0b9668a891de3a0cc53", size = 213521 },
+    { url = "https://files.pythonhosted.org/packages/8d/2a/1da1ada2e3044fcd4a3254fb3576e160b8fe5b36d705c8a31f793423f763/coverage-7.8.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e2f6fe3654468d061942591aef56686131335b7a8325684eda85dacdf311356c", size = 211876 },
+    { url = "https://files.pythonhosted.org/packages/70/e9/3d715ffd5b6b17a8be80cd14a8917a002530a99943cc1939ad5bb2aa74b9/coverage-7.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:76090fab50610798cc05241bf83b603477c40ee87acd358b66196ab0ca44ffa1", size = 212130 },
+    { url = "https://files.pythonhosted.org/packages/a0/02/fdce62bb3c21649abfd91fbdcf041fb99be0d728ff00f3f9d54d97ed683e/coverage-7.8.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bd0a0a5054be160777a7920b731a0570284db5142abaaf81bcbb282b8d99279", size = 246176 },
+    { url = "https://files.pythonhosted.org/packages/a7/52/decbbed61e03b6ffe85cd0fea360a5e04a5a98a7423f292aae62423b8557/coverage-7.8.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da23ce9a3d356d0affe9c7036030b5c8f14556bd970c9b224f9c8205505e3b99", size = 243068 },
+    { url = "https://files.pythonhosted.org/packages/38/6c/d0e9c0cce18faef79a52778219a3c6ee8e336437da8eddd4ab3dbd8fadff/coverage-7.8.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9392773cffeb8d7e042a7b15b82a414011e9d2b5fdbbd3f7e6a6b17d5e21b20", size = 245328 },
+    { url = "https://files.pythonhosted.org/packages/f0/70/f703b553a2f6b6c70568c7e398ed0789d47f953d67fbba36a327714a7bca/coverage-7.8.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:876cbfd0b09ce09d81585d266c07a32657beb3eaec896f39484b631555be0fe2", size = 245099 },
+    { url = "https://files.pythonhosted.org/packages/ec/fb/4cbb370dedae78460c3aacbdad9d249e853f3bc4ce5ff0e02b1983d03044/coverage-7.8.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3da9b771c98977a13fbc3830f6caa85cae6c9c83911d24cb2d218e9394259c57", size = 243314 },
+    { url = "https://files.pythonhosted.org/packages/39/9f/1afbb2cb9c8699b8bc38afdce00a3b4644904e6a38c7bf9005386c9305ec/coverage-7.8.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a990f6510b3292686713bfef26d0049cd63b9c7bb17e0864f133cbfd2e6167f", size = 244489 },
+    { url = "https://files.pythonhosted.org/packages/79/fa/f3e7ec7d220bff14aba7a4786ae47043770cbdceeea1803083059c878837/coverage-7.8.2-cp312-cp312-win32.whl", hash = "sha256:bf8111cddd0f2b54d34e96613e7fbdd59a673f0cf5574b61134ae75b6f5a33b8", size = 214366 },
+    { url = "https://files.pythonhosted.org/packages/54/aa/9cbeade19b7e8e853e7ffc261df885d66bf3a782c71cba06c17df271f9e6/coverage-7.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:86a323a275e9e44cdf228af9b71c5030861d4d2610886ab920d9945672a81223", size = 215165 },
+    { url = "https://files.pythonhosted.org/packages/c4/73/e2528bf1237d2448f882bbebaec5c3500ef07301816c5c63464b9da4d88a/coverage-7.8.2-cp312-cp312-win_arm64.whl", hash = "sha256:820157de3a589e992689ffcda8639fbabb313b323d26388d02e154164c57b07f", size = 213548 },
+    { url = "https://files.pythonhosted.org/packages/1a/93/eb6400a745ad3b265bac36e8077fdffcf0268bdbbb6c02b7220b624c9b31/coverage-7.8.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ea561010914ec1c26ab4188aef8b1567272ef6de096312716f90e5baa79ef8ca", size = 211898 },
+    { url = "https://files.pythonhosted.org/packages/1b/7c/bdbf113f92683024406a1cd226a199e4200a2001fc85d6a6e7e299e60253/coverage-7.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cb86337a4fcdd0e598ff2caeb513ac604d2f3da6d53df2c8e368e07ee38e277d", size = 212171 },
+    { url = "https://files.pythonhosted.org/packages/91/22/594513f9541a6b88eb0dba4d5da7d71596dadef6b17a12dc2c0e859818a9/coverage-7.8.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a4636ddb666971345541b59899e969f3b301143dd86b0ddbb570bd591f1e85", size = 245564 },
+    { url = "https://files.pythonhosted.org/packages/1f/f4/2860fd6abeebd9f2efcfe0fd376226938f22afc80c1943f363cd3c28421f/coverage-7.8.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5040536cf9b13fb033f76bcb5e1e5cb3b57c4807fef37db9e0ed129c6a094257", size = 242719 },
+    { url = "https://files.pythonhosted.org/packages/89/60/f5f50f61b6332451520e6cdc2401700c48310c64bc2dd34027a47d6ab4ca/coverage-7.8.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc67994df9bcd7e0150a47ef41278b9e0a0ea187caba72414b71dc590b99a108", size = 244634 },
+    { url = "https://files.pythonhosted.org/packages/3b/70/7f4e919039ab7d944276c446b603eea84da29ebcf20984fb1fdf6e602028/coverage-7.8.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e6c86888fd076d9e0fe848af0a2142bf606044dc5ceee0aa9eddb56e26895a0", size = 244824 },
+    { url = "https://files.pythonhosted.org/packages/26/45/36297a4c0cea4de2b2c442fe32f60c3991056c59cdc3cdd5346fbb995c97/coverage-7.8.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:684ca9f58119b8e26bef860db33524ae0365601492e86ba0b71d513f525e7050", size = 242872 },
+    { url = "https://files.pythonhosted.org/packages/a4/71/e041f1b9420f7b786b1367fa2a375703889ef376e0d48de9f5723fb35f11/coverage-7.8.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8165584ddedb49204c4e18da083913bdf6a982bfb558632a79bdaadcdafd0d48", size = 244179 },
+    { url = "https://files.pythonhosted.org/packages/bd/db/3c2bf49bdc9de76acf2491fc03130c4ffc51469ce2f6889d2640eb563d77/coverage-7.8.2-cp313-cp313-win32.whl", hash = "sha256:34759ee2c65362163699cc917bdb2a54114dd06d19bab860725f94ef45a3d9b7", size = 214393 },
+    { url = "https://files.pythonhosted.org/packages/c6/dc/947e75d47ebbb4b02d8babb1fad4ad381410d5bc9da7cfca80b7565ef401/coverage-7.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:2f9bc608fbafaee40eb60a9a53dbfb90f53cc66d3d32c2849dc27cf5638a21e3", size = 215194 },
+    { url = "https://files.pythonhosted.org/packages/90/31/a980f7df8a37eaf0dc60f932507fda9656b3a03f0abf188474a0ea188d6d/coverage-7.8.2-cp313-cp313-win_arm64.whl", hash = "sha256:9fe449ee461a3b0c7105690419d0b0aba1232f4ff6d120a9e241e58a556733f7", size = 213580 },
+    { url = "https://files.pythonhosted.org/packages/8a/6a/25a37dd90f6c95f59355629417ebcb74e1c34e38bb1eddf6ca9b38b0fc53/coverage-7.8.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:8369a7c8ef66bded2b6484053749ff220dbf83cba84f3398c84c51a6f748a008", size = 212734 },
+    { url = "https://files.pythonhosted.org/packages/36/8b/3a728b3118988725f40950931abb09cd7f43b3c740f4640a59f1db60e372/coverage-7.8.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:159b81df53a5fcbc7d45dae3adad554fdbde9829a994e15227b3f9d816d00b36", size = 212959 },
+    { url = "https://files.pythonhosted.org/packages/53/3c/212d94e6add3a3c3f412d664aee452045ca17a066def8b9421673e9482c4/coverage-7.8.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6fcbbd35a96192d042c691c9e0c49ef54bd7ed865846a3c9d624c30bb67ce46", size = 257024 },
+    { url = "https://files.pythonhosted.org/packages/a4/40/afc03f0883b1e51bbe804707aae62e29c4e8c8bbc365c75e3e4ddeee9ead/coverage-7.8.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05364b9cc82f138cc86128dc4e2e1251c2981a2218bfcd556fe6b0fbaa3501be", size = 252867 },
+    { url = "https://files.pythonhosted.org/packages/18/a2/3699190e927b9439c6ded4998941a3c1d6fa99e14cb28d8536729537e307/coverage-7.8.2-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46d532db4e5ff3979ce47d18e2fe8ecad283eeb7367726da0e5ef88e4fe64740", size = 255096 },
+    { url = "https://files.pythonhosted.org/packages/b4/06/16e3598b9466456b718eb3e789457d1a5b8bfb22e23b6e8bbc307df5daf0/coverage-7.8.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4000a31c34932e7e4fa0381a3d6deb43dc0c8f458e3e7ea6502e6238e10be625", size = 256276 },
+    { url = "https://files.pythonhosted.org/packages/a7/d5/4b5a120d5d0223050a53d2783c049c311eea1709fa9de12d1c358e18b707/coverage-7.8.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:43ff5033d657cd51f83015c3b7a443287250dc14e69910577c3e03bd2e06f27b", size = 254478 },
+    { url = "https://files.pythonhosted.org/packages/ba/85/f9ecdb910ecdb282b121bfcaa32fa8ee8cbd7699f83330ee13ff9bbf1a85/coverage-7.8.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94316e13f0981cbbba132c1f9f365cac1d26716aaac130866ca812006f662199", size = 255255 },
+    { url = "https://files.pythonhosted.org/packages/50/63/2d624ac7d7ccd4ebbd3c6a9eba9d7fc4491a1226071360d59dd84928ccb2/coverage-7.8.2-cp313-cp313t-win32.whl", hash = "sha256:3f5673888d3676d0a745c3d0e16da338c5eea300cb1f4ada9c872981265e76d8", size = 215109 },
+    { url = "https://files.pythonhosted.org/packages/22/5e/7053b71462e970e869111c1853afd642212568a350eba796deefdfbd0770/coverage-7.8.2-cp313-cp313t-win_amd64.whl", hash = "sha256:2c08b05ee8d7861e45dc5a2cc4195c8c66dca5ac613144eb6ebeaff2d502e73d", size = 216268 },
+    { url = "https://files.pythonhosted.org/packages/07/69/afa41aa34147655543dbe96994f8a246daf94b361ccf5edfd5df62ce066a/coverage-7.8.2-cp313-cp313t-win_arm64.whl", hash = "sha256:1e1448bb72b387755e1ff3ef1268a06617afd94188164960dba8d0245a46004b", size = 214071 },
+    { url = "https://files.pythonhosted.org/packages/69/2f/572b29496d8234e4a7773200dd835a0d32d9e171f2d974f3fe04a9dbc271/coverage-7.8.2-pp39.pp310.pp311-none-any.whl", hash = "sha256:ec455eedf3ba0bbdf8f5a570012617eb305c63cb9f03428d39bf544cb2b94837", size = 203636 },
+    { url = "https://files.pythonhosted.org/packages/a0/1a/0b9c32220ad694d66062f571cc5cedfa9997b64a591e8a500bb63de1bd40/coverage-7.8.2-py3-none-any.whl", hash = "sha256:726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32", size = 203623 },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -28,6 +95,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
 name = "just-bin"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
@@ -36,6 +112,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/60/62/410e12011b4a19f9de25981816296323ab5fbc875c520ca0bf8d8196db24/just_bin-1.40.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e509e4050e8a0f44b782f0ab82108282bf6145a536739941d348ca80a94454a6", size = 1599038 },
     { url = "https://files.pythonhosted.org/packages/5b/20/d51ab63cdc335bde9c0ca02f7d041bbd07429835391fc2cd37f5fa444fc6/just_bin-1.40.0-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:4c5c34e531bb5b0c9517b4e97afaf293328a9f000f4741dfc239a2fa52942f10", size = 1908867 },
     { url = "https://files.pythonhosted.org/packages/c0/a9/51bbefa1f45f4fdc002f99fa696bd7f16cc78cbf0fb4d1f0b95229f2a58c/just_bin-1.40.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:fb58d18ad818b55cf66f522a1d83e6c0c8f6faabf8d659c4f4447f378daf7f86", size = 1731810 },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
 ]
 
 [[package]]
@@ -98,6 +183,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
 name = "pyserial"
 version = "3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -116,6 +210,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4a/9a/8477699dcbc1882ea51dcff4d3c25aa3f2063ed8f7d7a849fd8f610506b6/pyserial-asyncio-0.6.tar.gz", hash = "sha256:b6032923e05e9d75ec17a5af9a98429c46d2839adfaf80604d52e0faacd7a32f", size = 31322 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/24/c820cf15f87f7b164e83710c1852d4f900d9793961579e5ef64189bc0c10/pyserial_asyncio-0.6-py3-none-any.whl", hash = "sha256:de9337922619421b62b9b1a84048634b3ac520e1d690a674ed246a2af7ce1fc5", size = 7594 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976 },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841 },
 ]
 
 [[package]]
@@ -166,6 +300,9 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "just-bin" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -178,7 +315,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "just-bin", specifier = ">=1.40.0" }]
+dev = [
+    { name = "just-bin", specifier = ">=1.40.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+]
 
 [[package]]
 name = "setuptools"
@@ -196,6 +338,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077 },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429 },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067 },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030 },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898 },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894 },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319 },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273 },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310 },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309 },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762 },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453 },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349 },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159 },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243 },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645 },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584 },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875 },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418 },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708 },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582 },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543 },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691 },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170 },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530 },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666 },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954 },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724 },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add complete test suite for sensor data receiver project. Includes 19 tests (13 unit, 2 integration) with pytest-asyncio support. All tests passing. Fixes #1