### PR TITLE
Add GitHub Actions workflow for sensor_data_reciver tests (uv対応)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Sensor Data Receiver CI
+
+on:
+  push:
+    paths:
+      - 'server/sensor_data_reciver/**'
+  pull_request:
+    paths:
+      - 'server/sensor_data_reciver/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server/sensor_data_reciver
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          uv sync --locked --all-extras --dev
+
+      - name: Run unit and integration tests
+        run: |
+          uv run pytest tests/unit
+          uv run pytest tests/integration

--- a/server/sensor_data_reciver/README.md
+++ b/server/sensor_data_reciver/README.md
@@ -81,6 +81,21 @@ uv run python app.py -p /dev/cu.usbmodem12341 -b 115200
 
 Once started, the server begins receiving data from the specified serial port. Received images are saved to the `images_usb_async` directory. You can stop the server with Ctrl+C.
 
+### Testing
+
+To run unit tests and integration tests, use the following commands (requires uv):
+
+```bash
+uv run pytest tests/unit
+uv run pytest tests/integration
+```
+
+You can also run all tests at once:
+
+```bash
+uv run pytest
+```
+
 ## Data Protocol
 
 This server expects the following custom frame format transmitted from `usb_cdc_receiver`.

--- a/server/sensor_data_reciver/README_JA.md
+++ b/server/sensor_data_reciver/README_JA.md
@@ -81,6 +81,21 @@ uv run python app.py -p /dev/cu.usbmodem12341 -b 115200
 
 サーバーは起動すると、指定されたシリアルポートからのデータ受信を開始します。受信した画像は `images_usb_async` ディレクトリに保存されます。Ctrl+Cでサーバーを停止できます。
 
+### テスト実行
+
+ユニットテスト・結合テストは以下のコマンドで実行できます（uvが必要です）：
+
+```bash
+uv run pytest tests/unit
+uv run pytest tests/integration
+```
+
+すべてのテストを一括で実行する場合：
+
+```bash
+uv run pytest
+```
+
 ## データプロトコル
 
 このサーバーは `usb_cdc_receiver` から送信される以下のカスタムフレーム形式を期待します。


### PR DESCRIPTION
sensor_data_reciverのUnitTest/IntegrationTestをGitHub Actionsでuvを使って自動実行するワークフローを追加し、READMEにもテスト実行方法を追記しました。