### PR TITLE
Phase1: add HASH/EOF cycle tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
       run:
         working-directory: server/sensor_data_reciver
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
       - name: Cache Python/uv dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-${{ hashFiles('**/uv.lock') }}
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-uv-
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Cache Python/uv dependencies
         uses: actions/cache@v5

--- a/.github/workflows/m5stack_qemu_smoke.yml
+++ b/.github/workflows/m5stack_qemu_smoke.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify QEMU binary exists
         run: |

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -22,7 +22,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -108,7 +108,7 @@ jobs:
           
       - name: Comment on PR (if applicable)
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -87,7 +87,7 @@ jobs:
           
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-executables
           path: |
@@ -102,7 +102,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -134,7 +134,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/server/sensor_data_reciver/protocol/__init__.py
+++ b/server/sensor_data_reciver/protocol/__init__.py
@@ -6,6 +6,7 @@ from .constants import (
     FRAME_TYPE_HASH, FRAME_TYPE_DATA, FRAME_TYPE_EOF,
     HEADER_LENGTH, FOOTER_LENGTH
 )
+from .cycle_tracker import CycleTracker, SenderCycleState
 from .frame_parser import FrameParser
 from .serial_handler import SerialProtocol
 from .streaming_handler import StreamingSerialProtocol
@@ -14,6 +15,6 @@ __all__ = [
     "MAC_ADDRESS_LENGTH", "FRAME_TYPE_LENGTH", "SEQUENCE_NUM_LENGTH", 
     "LENGTH_FIELD_BYTES", "CHECKSUM_LENGTH", "START_MARKER", "END_MARKER",
     "FRAME_TYPE_HASH", "FRAME_TYPE_DATA", "FRAME_TYPE_EOF",
-    "HEADER_LENGTH", "FOOTER_LENGTH", "FrameParser", "SerialProtocol",
-    "StreamingSerialProtocol"
+    "HEADER_LENGTH", "FOOTER_LENGTH", "CycleTracker", "SenderCycleState",
+    "FrameParser", "SerialProtocol", "StreamingSerialProtocol"
 ]

--- a/server/sensor_data_reciver/protocol/cycle_tracker.py
+++ b/server/sensor_data_reciver/protocol/cycle_tracker.py
@@ -163,6 +163,7 @@ class CycleTracker:
                     state.cycle_seq_num,
                     seq_num,
                 )
+                state.warning_emitted = True
             return state
 
         state.last_event_at = now if now is not None else time.monotonic()

--- a/server/sensor_data_reciver/protocol/cycle_tracker.py
+++ b/server/sensor_data_reciver/protocol/cycle_tracker.py
@@ -14,14 +14,6 @@ logger = logging.getLogger(__name__)
 TERMINAL_STATES = {"Completed", "TimedOut"}
 
 
-def _frame_type_name(frame_type: int) -> str:
-    return {
-        FRAME_TYPE_HASH: "HASH",
-        FRAME_TYPE_DATA: "DATA",
-        FRAME_TYPE_EOF: "EOF",
-    }.get(frame_type, f"UNKNOWN({frame_type})")
-
-
 @dataclass
 class SenderCycleState:
     sender_mac: str
@@ -126,6 +118,26 @@ class CycleTracker:
         state.cycle_state = "Completed"
         state.last_event_at = now if now is not None else time.monotonic()
         return state
+
+    def prune_terminal_states(
+        self, retention_seconds: float = 3600.0, now: Optional[float] = None
+    ) -> int:
+        """Remove terminal cycles that have been retained long enough."""
+        current_time = now if now is not None else time.monotonic()
+        removed = 0
+
+        for sender_mac, state in list(self._states.items()):
+            if state.cycle_state not in TERMINAL_STATES:
+                continue
+
+            if current_time - state.last_event_at < retention_seconds:
+                continue
+
+            del self._states[sender_mac]
+            self._cycle_counters.pop(sender_mac, None)
+            removed += 1
+
+        return removed
 
     def mark_timeout(
         self, sender_mac: str, now: Optional[float] = None

--- a/server/sensor_data_reciver/protocol/cycle_tracker.py
+++ b/server/sensor_data_reciver/protocol/cycle_tracker.py
@@ -7,8 +7,6 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict, Optional
 
-from .constants import FRAME_TYPE_DATA, FRAME_TYPE_EOF, FRAME_TYPE_HASH
-
 logger = logging.getLogger(__name__)
 
 TERMINAL_STATES = {"Completed", "TimedOut"}
@@ -25,8 +23,6 @@ class SenderCycleState:
     hash_received: bool = False
     eof_received: bool = False
     warning_emitted: bool = False
-    last_frame_type: Optional[int] = None
-    last_frame_seq_num: Optional[int] = None
 
 
 class CycleTracker:
@@ -43,8 +39,6 @@ class CycleTracker:
         self, sender_mac: str, seq_num: Optional[int], now: Optional[float] = None
     ) -> SenderCycleState:
         state = self._ensure_active_state(sender_mac, seq_num, "ReceivingData", now)
-        state.last_frame_type = FRAME_TYPE_DATA
-        state.last_frame_seq_num = seq_num
         state.cycle_state = "ReceivingData"
 
         if state.cycle_seq_num is None and seq_num is not None:
@@ -65,8 +59,6 @@ class CycleTracker:
     ) -> SenderCycleState:
         state = self._ensure_active_state(sender_mac, seq_num, "HashReceived", now)
         previous_cycle_seq = state.cycle_seq_num
-        state.last_frame_type = FRAME_TYPE_HASH
-        state.last_frame_seq_num = seq_num
         state.hash_received = True
         state.eof_received = False
         state.cycle_state = "HashReceived"
@@ -87,8 +79,6 @@ class CycleTracker:
         self, sender_mac: str, seq_num: Optional[int], now: Optional[float] = None
     ) -> SenderCycleState:
         state = self._ensure_active_state(sender_mac, seq_num, "EofReceived", now)
-        state.last_frame_type = FRAME_TYPE_EOF
-        state.last_frame_seq_num = seq_num
         state.eof_received = True
         state.cycle_state = "EofReceived"
 
@@ -199,5 +189,4 @@ class CycleTracker:
             cycle_state=initial_state,
             cycle_started_at=created_at,
             last_event_at=created_at,
-            last_frame_seq_num=seq_num,
         )

--- a/server/sensor_data_reciver/protocol/cycle_tracker.py
+++ b/server/sensor_data_reciver/protocol/cycle_tracker.py
@@ -1,0 +1,190 @@
+"""Per-sender cycle tracking for HASH / DATA / EOF frames."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from .constants import FRAME_TYPE_DATA, FRAME_TYPE_EOF, FRAME_TYPE_HASH
+
+logger = logging.getLogger(__name__)
+
+TERMINAL_STATES = {"Completed", "TimedOut"}
+
+
+def _frame_type_name(frame_type: int) -> str:
+    return {
+        FRAME_TYPE_HASH: "HASH",
+        FRAME_TYPE_DATA: "DATA",
+        FRAME_TYPE_EOF: "EOF",
+    }.get(frame_type, f"UNKNOWN({frame_type})")
+
+
+@dataclass
+class SenderCycleState:
+    sender_mac: str
+    cycle_id: int
+    cycle_seq_num: Optional[int] = None
+    cycle_state: str = "Idle"
+    cycle_started_at: float = field(default_factory=time.monotonic)
+    last_event_at: float = field(default_factory=time.monotonic)
+    hash_received: bool = False
+    eof_received: bool = False
+    warning_emitted: bool = False
+    last_frame_type: Optional[int] = None
+    last_frame_seq_num: Optional[int] = None
+
+
+class CycleTracker:
+    """Track one active cycle per sender MAC."""
+
+    def __init__(self) -> None:
+        self._states: Dict[str, SenderCycleState] = {}
+        self._cycle_counters: Dict[str, int] = {}
+
+    def get_state(self, sender_mac: str) -> Optional[SenderCycleState]:
+        return self._states.get(sender_mac)
+
+    def observe_data(
+        self, sender_mac: str, seq_num: Optional[int], now: Optional[float] = None
+    ) -> SenderCycleState:
+        state = self._ensure_active_state(sender_mac, seq_num, "ReceivingData", now)
+        state.last_frame_type = FRAME_TYPE_DATA
+        state.last_frame_seq_num = seq_num
+        state.cycle_state = "ReceivingData"
+
+        if state.cycle_seq_num is None and seq_num is not None:
+            state.cycle_seq_num = seq_num
+
+        if state.hash_received:
+            logger.warning(
+                "DATA received after HASH for %s (cycle_seq=%s, seq=%s)",
+                sender_mac,
+                state.cycle_seq_num,
+                seq_num,
+            )
+
+        return state
+
+    def observe_hash(
+        self, sender_mac: str, seq_num: Optional[int], now: Optional[float] = None
+    ) -> SenderCycleState:
+        state = self._ensure_active_state(sender_mac, seq_num, "HashReceived", now)
+        previous_cycle_seq = state.cycle_seq_num
+        state.last_frame_type = FRAME_TYPE_HASH
+        state.last_frame_seq_num = seq_num
+        state.hash_received = True
+        state.eof_received = False
+        state.cycle_state = "HashReceived"
+
+        if seq_num is not None:
+            state.cycle_seq_num = seq_num
+
+        if previous_cycle_seq is not None and previous_cycle_seq != state.cycle_seq_num:
+            logger.debug(
+                "Updated cycle sequence for %s after HASH: %s",
+                sender_mac,
+                state.cycle_seq_num,
+            )
+
+        return state
+
+    def observe_eof(
+        self, sender_mac: str, seq_num: Optional[int], now: Optional[float] = None
+    ) -> SenderCycleState:
+        state = self._ensure_active_state(sender_mac, seq_num, "EofReceived", now)
+        state.last_frame_type = FRAME_TYPE_EOF
+        state.last_frame_seq_num = seq_num
+        state.eof_received = True
+        state.cycle_state = "EofReceived"
+
+        if state.cycle_seq_num is None and seq_num is not None:
+            state.cycle_seq_num = seq_num
+
+        if not state.hash_received and not state.warning_emitted:
+            logger.warning(
+                "EOF received but HASH was not received for %s (cycle_seq=%s)",
+                sender_mac,
+                state.cycle_seq_num,
+            )
+            state.warning_emitted = True
+
+        return state
+
+    def complete_cycle(
+        self, sender_mac: str, now: Optional[float] = None
+    ) -> Optional[SenderCycleState]:
+        state = self._states.get(sender_mac)
+        if state is None:
+            return None
+
+        if state.cycle_state in TERMINAL_STATES:
+            return state
+
+        state.cycle_state = "Completed"
+        state.last_event_at = now if now is not None else time.monotonic()
+        return state
+
+    def mark_timeout(
+        self, sender_mac: str, now: Optional[float] = None
+    ) -> Optional[SenderCycleState]:
+        state = self._states.get(sender_mac)
+        if state is None:
+            return None
+
+        state.cycle_state = "TimedOut"
+        state.last_event_at = now if now is not None else time.monotonic()
+        return state
+
+    def _ensure_active_state(
+        self,
+        sender_mac: str,
+        seq_num: Optional[int],
+        initial_state: str,
+        now: Optional[float],
+    ) -> SenderCycleState:
+        state = self._states.get(sender_mac)
+        if state is None or state.cycle_state in TERMINAL_STATES:
+            state = self._create_state(sender_mac, seq_num, initial_state, now)
+            self._states[sender_mac] = state
+            if initial_state == "HashReceived":
+                logger.warning(
+                    "HASH received before DATA for %s (cycle_seq=%s, seq=%s)",
+                    sender_mac,
+                    state.cycle_seq_num,
+                    seq_num,
+                )
+            elif initial_state == "EofReceived":
+                logger.warning(
+                    "EOF received before DATA/HASH for %s (cycle_seq=%s, seq=%s)",
+                    sender_mac,
+                    state.cycle_seq_num,
+                    seq_num,
+                )
+            return state
+
+        state.last_event_at = now if now is not None else time.monotonic()
+        return state
+
+    def _create_state(
+        self,
+        sender_mac: str,
+        seq_num: Optional[int],
+        initial_state: str,
+        now: Optional[float],
+    ) -> SenderCycleState:
+        cycle_id = self._cycle_counters.get(sender_mac, 0) + 1
+        self._cycle_counters[sender_mac] = cycle_id
+
+        created_at = now if now is not None else time.monotonic()
+        return SenderCycleState(
+            sender_mac=sender_mac,
+            cycle_id=cycle_id,
+            cycle_seq_num=seq_num,
+            cycle_state=initial_state,
+            cycle_started_at=created_at,
+            last_event_at=created_at,
+            last_frame_seq_num=seq_num,
+        )

--- a/server/sensor_data_reciver/protocol/serial_handler.py
+++ b/server/sensor_data_reciver/protocol/serial_handler.py
@@ -108,6 +108,8 @@ class SerialProtocol(asyncio.Protocol):
 
     def process_buffer(self):
         """Process the buffer to find and handle complete frames with enhanced frame format."""
+        self.cycle_tracker.prune_terminal_states()
+
         # デバッグ: バッファ内にEOFマーカーが含まれているかチェック
         if config.DEBUG_FRAME_PARSING and b'EOF' in self.buffer:
             eof_index = self.buffer.find(b'EOF')

--- a/server/sensor_data_reciver/protocol/serial_handler.py
+++ b/server/sensor_data_reciver/protocol/serial_handler.py
@@ -75,6 +75,7 @@ class SerialProtocol(asyncio.Protocol):
 
         # sender単位のサイクル状態トラッカー
         self.cycle_tracker = CycleTracker()
+        self._last_cycle_prune_at = 0.0
         
         logger.info("Serial Protocol initialized.")
         
@@ -108,7 +109,7 @@ class SerialProtocol(asyncio.Protocol):
 
     def process_buffer(self):
         """Process the buffer to find and handle complete frames with enhanced frame format."""
-        self.cycle_tracker.prune_terminal_states()
+        self._prune_cycle_states_if_due()
 
         # デバッグ: バッファ内にEOFマーカーが含まれているかチェック
         if config.DEBUG_FRAME_PARSING and b'EOF' in self.buffer:
@@ -474,6 +475,8 @@ class SerialProtocol(asyncio.Protocol):
     def _send_sleep_command(self, sender_mac: str, voltage: float):
         """スリープコマンドを送信（重複送信防止機能付き）"""
         current_time = time.time()
+
+        self._prune_cycle_states_if_due(current_time)
         
         # 古い送信履歴をクリーンアップ（1時間以上前のものを削除）
         cleanup_threshold = current_time - 3600  # 1時間
@@ -672,6 +675,16 @@ class SerialProtocol(asyncio.Protocol):
         if sender_mac in self.has_image_data_cache:
             del self.has_image_data_cache[sender_mac]
         logger.debug(f"Cleaned up cache for {sender_mac}")
+
+    def _prune_cycle_states_if_due(self, now: float | None = None, min_interval_seconds: float = 60.0) -> int:
+        """CycleTracker の terminal state を低頻度で回収する。"""
+        current_time = now if now is not None else time.time()
+        if current_time - self._last_cycle_prune_at < min_interval_seconds:
+            return 0
+
+        removed = self.cycle_tracker.prune_terminal_states(now=current_time)
+        self._last_cycle_prune_at = current_time
+        return removed
 
     def connection_lost(self, exc):
         log_prefix = f"connection_lost ({id(self)}):"

--- a/server/sensor_data_reciver/protocol/serial_handler.py
+++ b/server/sensor_data_reciver/protocol/serial_handler.py
@@ -10,6 +10,7 @@ from .constants import (
     MAC_ADDRESS_LENGTH, FRAME_TYPE_LENGTH, SEQUENCE_NUM_LENGTH, LENGTH_FIELD_BYTES,
     CHECKSUM_LENGTH
 )
+from .cycle_tracker import CycleTracker
 from .frame_parser import FrameParser, FrameSyncError
 
 # 修正: 絶対インポートまたは動的インポートを使用
@@ -71,6 +72,9 @@ class SerialProtocol(asyncio.Protocol):
         
         # 最後のデータフレーム受信時間（画像受信中の判定用）
         self.last_data_frame_time = {}  # {sender_mac: timestamp}
+
+        # sender単位のサイクル状態トラッカー
+        self.cycle_tracker = CycleTracker()
         
         logger.info("Serial Protocol initialized.")
         
@@ -348,12 +352,12 @@ class SerialProtocol(asyncio.Protocol):
                 frame_type_str = "UNKNOWN"
                 if frame_type == FRAME_TYPE_HASH:
                     frame_type_str = "HASH"
-                    self._process_hash_frame(sender_mac, chunk_data)
+                    self._process_hash_frame(sender_mac, chunk_data, seq_num)
                     
                 elif frame_type == FRAME_TYPE_EOF:
                     frame_type_str = "EOF"
                     logger.info(f"Processing EOF frame from {sender_mac} (seq={seq_num}, data_len={data_len})")
-                    self._process_eof_frame(sender_mac)
+                    self._process_eof_frame(sender_mac, seq_num)
                 
                 elif frame_type == FRAME_TYPE_DATA:
                     frame_type_str = "DATA"
@@ -399,15 +403,18 @@ class SerialProtocol(asyncio.Protocol):
                 
                 self.frame_start_time = None
 
-    def _process_hash_frame(self, sender_mac: str, chunk_data: bytes):
+    def _process_hash_frame(self, sender_mac: str, chunk_data: bytes, seq_num: int):
         """HASH フレームの処理"""
+        cycle_state = self.cycle_tracker.observe_hash(sender_mac, seq_num)
         try:
             payload_str = chunk_data[5:].decode('ascii')  # 'HASH:' をスキップ
         except UnicodeDecodeError:
             logger.warning(f"Could not decode HASH payload from {sender_mac}")
             return
 
-        logger.info(f"Received HASH frame from {sender_mac}: {payload_str}")
+        logger.info(
+            f"Received HASH frame from {sender_mac} (cycle_seq={cycle_state.cycle_seq_num}): {payload_str}"
+        )
         payload_split = payload_str.split(",")
         
         if len(payload_split) < 2:
@@ -500,7 +507,7 @@ class SerialProtocol(asyncio.Protocol):
         else:
             logger.warning(f"No transport available to send sleep command for {sender_mac}")
 
-    def _process_eof_frame(self, sender_mac: str):
+    def _process_eof_frame(self, sender_mac: str, seq_num: int | None):
         """EOF フレームの処理"""
         current_time = time.time()
         
@@ -510,6 +517,8 @@ class SerialProtocol(asyncio.Protocol):
             if time_since_last_eof < 5:  # 5秒以内の重複はスキップ
                 logger.warning(f"Skipping duplicate EOF for {sender_mac} (last processed {time_since_last_eof:.1f}s ago)")
                 return
+
+        cycle_state = self.cycle_tracker.observe_eof(sender_mac, seq_num)
         
         # EOF処理済みフラグを設定
         self.eof_processed[sender_mac] = current_time
@@ -518,7 +527,10 @@ class SerialProtocol(asyncio.Protocol):
             image_data = bytes(self.image_buffers[sender_mac])
             image_size = len(image_data)
             
-            logger.info(f"EOF frame received for {sender_mac}. Assembling image ({image_size} bytes).")
+            logger.info(
+                f"EOF frame received for {sender_mac} (cycle_seq={cycle_state.cycle_seq_num}). "
+                f"Assembling image ({image_size} bytes)."
+            )
             
             # テスト環境では画像検証をスキップ
             if not config.IS_TEST_ENV:
@@ -560,6 +572,7 @@ class SerialProtocol(asyncio.Protocol):
         
         # EOF処理完了後、画像保存の成功/失敗に関わらずスリープコマンドを送信
         self._send_sleep_command_after_eof(sender_mac)
+        self.cycle_tracker.complete_cycle(sender_mac)
 
     def _send_sleep_command_after_eof(self, sender_mac: str):
         """EOF処理完了後にスリープコマンドを送信（xiaの受信体制が整った後）"""
@@ -612,6 +625,7 @@ class SerialProtocol(asyncio.Protocol):
 
     def _process_data_frame(self, sender_mac: str, chunk_data: bytes, seq_num: int):
         """DATA フレームの処理"""
+        self.cycle_tracker.observe_data(sender_mac, seq_num)
         if sender_mac not in self.image_buffers:
             self.image_buffers[sender_mac] = bytearray()
             self.sequence_tracking[sender_mac] = seq_num
@@ -706,7 +720,7 @@ class SerialProtocol(asyncio.Protocol):
                     if sender_mac in self.image_buffers and len(self.image_buffers[sender_mac]) > 0:
                         image_size = len(self.image_buffers[sender_mac])
                         logger.info(f"Raw EOF marker detected for {sender_mac} with {image_size} bytes")
-                        self._process_eof_frame(sender_mac)
+                        self._process_eof_frame(sender_mac, None)
                         processed_eof = True
                         break
                 
@@ -718,7 +732,7 @@ class SerialProtocol(asyncio.Protocol):
                         logger.info(f"Raw EOF marker detected for {sender_mac} (no image data, voltage-only)")
                         # 1秒待機
                         time.sleep(3)
-                        self._process_eof_frame(sender_mac)  # 画像バッファがなくてもEOF処理を実行
+                        self._process_eof_frame(sender_mac, None)  # 画像バッファがなくてもEOF処理を実行
                         processed_eof = True
                         break
                 

--- a/server/sensor_data_reciver/protocol/serial_handler.py
+++ b/server/sensor_data_reciver/protocol/serial_handler.py
@@ -474,7 +474,7 @@ class SerialProtocol(asyncio.Protocol):
 
     def _send_sleep_command(self, sender_mac: str, voltage: float):
         """スリープコマンドを送信（重複送信防止機能付き）"""
-        current_time = time.time()
+        current_time = time.monotonic()
 
         self._prune_cycle_states_if_due(current_time)
         
@@ -678,7 +678,7 @@ class SerialProtocol(asyncio.Protocol):
 
     def _prune_cycle_states_if_due(self, now: float | None = None, min_interval_seconds: float = 60.0) -> int:
         """CycleTracker の terminal state を低頻度で回収する。"""
-        current_time = now if now is not None else time.time()
+        current_time = now if now is not None else time.monotonic()
         if current_time - self._last_cycle_prune_at < min_interval_seconds:
             return 0
 

--- a/server/sensor_data_reciver/protocol/serial_handler.py
+++ b/server/sensor_data_reciver/protocol/serial_handler.py
@@ -405,21 +405,23 @@ class SerialProtocol(asyncio.Protocol):
 
     def _process_hash_frame(self, sender_mac: str, chunk_data: bytes, seq_num: int):
         """HASH フレームの処理"""
-        cycle_state = self.cycle_tracker.observe_hash(sender_mac, seq_num)
         try:
             payload_str = chunk_data[5:].decode('ascii')  # 'HASH:' をスキップ
         except UnicodeDecodeError:
             logger.warning(f"Could not decode HASH payload from {sender_mac}")
             return
 
-        logger.info(
-            f"Received HASH frame from {sender_mac} (cycle_seq={cycle_state.cycle_seq_num}): {payload_str}"
-        )
         payload_split = payload_str.split(",")
         
         if len(payload_split) < 2:
             logger.warning(f"Invalid HASH payload format from {sender_mac}: {payload_str}")
             return
+
+        cycle_state = self.cycle_tracker.observe_hash(sender_mac, seq_num)
+
+        logger.info(
+            f"Received HASH frame from {sender_mac} (cycle_seq={cycle_state.cycle_seq_num}): {payload_str}"
+        )
 
         hash_value = payload_split[0]
         volt_log_entry = payload_split[1]
@@ -730,7 +732,7 @@ class SerialProtocol(asyncio.Protocol):
                     # 電圧キャッシュから最新のsender_macを特定
                     for sender_mac in list(self.voltage_cache.keys()):
                         logger.info(f"Raw EOF marker detected for {sender_mac} (no image data, voltage-only)")
-                        # 1秒待機
+                        # 3秒待機
                         time.sleep(3)
                         self._process_eof_frame(sender_mac, None)  # 画像バッファがなくてもEOF処理を実行
                         processed_eof = True

--- a/server/sensor_data_reciver/protocol/serial_handler.py
+++ b/server/sensor_data_reciver/protocol/serial_handler.py
@@ -521,60 +521,61 @@ class SerialProtocol(asyncio.Protocol):
                 return
 
         cycle_state = self.cycle_tracker.observe_eof(sender_mac, seq_num)
-        
-        # EOF処理済みフラグを設定
-        self.eof_processed[sender_mac] = current_time
-        
-        if sender_mac in self.image_buffers:
-            image_data = bytes(self.image_buffers[sender_mac])
-            image_size = len(image_data)
+        try:
+            # EOF処理済みフラグを設定
+            self.eof_processed[sender_mac] = current_time
             
-            logger.info(
-                f"EOF frame received for {sender_mac} (cycle_seq={cycle_state.cycle_seq_num}). "
-                f"Assembling image ({image_size} bytes)."
-            )
-            
-            # テスト環境では画像検証をスキップ
-            if not config.IS_TEST_ENV:
-                # 画像データの基本検証
-                if image_size < 1000:  # 1KB未満は明らかに不正
-                    logger.error(f"Image data too small ({image_size} bytes), discarding")
-                    self._cleanup_image_buffers(sender_mac)
-                    # 画像保存をスキップしてもスリープコマンドは送信
-                    self._send_sleep_command_after_eof(sender_mac)
-                    return
-                    
-                # JPEGヘッダーの確認
-                if not image_data.startswith(b'\xff\xd8'):
-                    logger.error(f"Invalid JPEG header detected for {sender_mac}, discarding corrupted image")
-                    self._cleanup_image_buffers(sender_mac)
-                    # 画像保存をスキップしてもスリープコマンドは送信
-                    self._send_sleep_command_after_eof(sender_mac)
-                    return
-                    
-                # JPEGフッターの確認
-                if not image_data.endswith(b'\xff\xd9'):
-                    logger.warning(f"JPEG footer missing or corrupted, data ends with: {image_data[-10:].hex()}")
-                    logger.warning("Attempting to save image anyway")
+            if sender_mac in self.image_buffers:
+                image_data = bytes(self.image_buffers[sender_mac])
+                image_size = len(image_data)
+                
+                logger.info(
+                    f"EOF frame received for {sender_mac} (cycle_seq={cycle_state.cycle_seq_num}). "
+                    f"Assembling image ({image_size} bytes)."
+                )
+                
+                # テスト環境では画像検証をスキップ
+                if not config.IS_TEST_ENV:
+                    # 画像データの基本検証
+                    if image_size < 1000:  # 1KB未満は明らかに不正
+                        logger.error(f"Image data too small ({image_size} bytes), discarding")
+                        self._cleanup_image_buffers(sender_mac)
+                        # 画像保存をスキップしてもスリープコマンドは送信
+                        self._send_sleep_command_after_eof(sender_mac)
+                        return
+                        
+                    # JPEGヘッダーの確認
+                    if not image_data.startswith(b'\xff\xd8'):
+                        logger.error(f"Invalid JPEG header detected for {sender_mac}, discarding corrupted image")
+                        self._cleanup_image_buffers(sender_mac)
+                        # 画像保存をスキップしてもスリープコマンドは送信
+                        self._send_sleep_command_after_eof(sender_mac)
+                        return
+                        
+                    # JPEGフッターの確認
+                    if not image_data.endswith(b'\xff\xd9'):
+                        logger.warning(f"JPEG footer missing or corrupted, data ends with: {image_data[-10:].hex()}")
+                        logger.warning("Attempting to save image anyway")
+                else:
+                    logger.debug("Test environment detected, skipping image validation")
+                
+                # イベントループが実行中かチェックしてからタスクを作成
+                if self._has_running_event_loop():
+                    try:
+                        asyncio.create_task(save_image(sender_mac, image_data, self.stats))
+                    except Exception as e:
+                        logger.error(f"Error creating save_image task for {sender_mac}: {e}")
+                else:
+                    logger.warning(f"No event loop running, cannot create save_image task for {sender_mac}")
+                
+                self._cleanup_image_buffers(sender_mac)
             else:
-                logger.debug("Test environment detected, skipping image validation")
+                logger.warning(f"EOF for {sender_mac} but no buffer found.")
             
-            # イベントループが実行中かチェックしてからタスクを作成
-            if self._has_running_event_loop():
-                try:
-                    asyncio.create_task(save_image(sender_mac, image_data, self.stats))
-                except Exception as e:
-                    logger.error(f"Error creating save_image task for {sender_mac}: {e}")
-            else:
-                logger.warning(f"No event loop running, cannot create save_image task for {sender_mac}")
-            
-            self._cleanup_image_buffers(sender_mac)
-        else:
-            logger.warning(f"EOF for {sender_mac} but no buffer found.")
-        
-        # EOF処理完了後、画像保存の成功/失敗に関わらずスリープコマンドを送信
-        self._send_sleep_command_after_eof(sender_mac)
-        self.cycle_tracker.complete_cycle(sender_mac)
+            # EOF処理完了後、画像保存の成功/失敗に関わらずスリープコマンドを送信
+            self._send_sleep_command_after_eof(sender_mac)
+        finally:
+            self.cycle_tracker.complete_cycle(sender_mac)
 
     def _send_sleep_command_after_eof(self, sender_mac: str):
         """EOF処理完了後にスリープコマンドを送信（xiaの受信体制が整った後）"""

--- a/server/sensor_data_reciver/protocol/streaming_handler.py
+++ b/server/sensor_data_reciver/protocol/streaming_handler.py
@@ -129,6 +129,8 @@ class StreamingSerialProtocol(asyncio.Protocol):
     async def _process_streaming_buffer(self):
         """ストリーミング対応バッファ処理"""
         while True:
+            self.cycle_tracker.prune_terminal_states()
+
             # フレームタイムアウトチェック
             await self._check_frame_timeout()
 
@@ -682,6 +684,7 @@ class StreamingSerialProtocol(asyncio.Protocol):
             try:
                 await asyncio.sleep(5.0)  # 5秒間隔でチェック
                 await self.streaming_processor.check_stream_timeouts()
+                self.cycle_tracker.prune_terminal_states()
             except asyncio.CancelledError:
                 logger.info("Timeout check loop cancelled")
                 break

--- a/server/sensor_data_reciver/protocol/streaming_handler.py
+++ b/server/sensor_data_reciver/protocol/streaming_handler.py
@@ -24,6 +24,7 @@ from .constants import (
     HEADER_LENGTH,
     FOOTER_LENGTH,
 )
+from .cycle_tracker import CycleTracker
 from .frame_parser import FrameParser
 
 # 絶対インポートを使用
@@ -83,6 +84,9 @@ class StreamingSerialProtocol(asyncio.Protocol):
 
         # 最後のデータフレーム受信時間
         self.last_data_frame_time = {}  # {sender_mac: timestamp}
+
+        # sender単位のサイクル状態トラッカー
+        self.cycle_tracker = CycleTracker()
 
         # タイムアウトチェックタスク
         self.timeout_check_task = None
@@ -293,27 +297,30 @@ class StreamingSerialProtocol(asyncio.Protocol):
             )
 
         if frame_type == FRAME_TYPE_HASH:
-            await self._process_streaming_hash_frame(sender_mac, chunk_data)
+            await self._process_streaming_hash_frame(sender_mac, chunk_data, seq_num)
 
         elif frame_type == FRAME_TYPE_DATA:
             await self._process_streaming_data_frame(sender_mac, chunk_data, seq_num)
 
         elif frame_type == FRAME_TYPE_EOF:
             logger.info(f"Received EOF frame for {sender_mac}")
-            await self._process_streaming_eof_frame(sender_mac)
+            await self._process_streaming_eof_frame(sender_mac, seq_num)
 
         else:
             logger.warning(f"Unknown frame type {frame_type} from {sender_mac}")
 
-    async def _process_streaming_hash_frame(self, sender_mac: str, chunk_data: bytes):
+    async def _process_streaming_hash_frame(self, sender_mac: str, chunk_data: bytes, seq_num: int):
         """HASHフレーム処理（ストリーミング対応）"""
+        cycle_state = self.cycle_tracker.observe_hash(sender_mac, seq_num)
         try:
             payload_str = chunk_data[5:].decode("ascii")  # 'HASH:' をスキップ
         except UnicodeDecodeError:
             logger.warning(f"Could not decode HASH payload from {sender_mac}")
             return
 
-        logger.info(f"Received HASH frame from {sender_mac}: {payload_str}")
+        logger.info(
+            f"Received HASH frame from {sender_mac} (cycle_seq={cycle_state.cycle_seq_num}): {payload_str}"
+        )
         payload_split = payload_str.split(",")
 
         if len(payload_split) < 2:
@@ -399,6 +406,7 @@ class StreamingSerialProtocol(asyncio.Protocol):
         self, sender_mac: str, chunk_data: bytes, seq_num: int
     ):
         """DATAフレーム処理（ストリーミング対応）"""
+        self.cycle_tracker.observe_data(sender_mac, seq_num)
 
         # 二重カプセル化（Double Framing）の検出と解除
         # ゲートウェイがSenderのフレームをそのままDATAフレームのペイロードとして
@@ -482,7 +490,9 @@ class StreamingSerialProtocol(asyncio.Protocol):
         else:
             logger.warning(f"Failed to process chunk for {sender_mac}")
 
-    async def _process_streaming_eof_frame(self, sender_mac: str):
+    async def _process_streaming_eof_frame(
+        self, sender_mac: str, seq_num: int | None
+    ):
         """EOFフレーム処理（ストリーミング対応）"""
         current_time = time.time()
 
@@ -496,7 +506,11 @@ class StreamingSerialProtocol(asyncio.Protocol):
                 )
                 return
 
-        logger.info(f"Processing EOF frame for {sender_mac}")
+        cycle_state = self.cycle_tracker.observe_eof(sender_mac, seq_num)
+
+        logger.info(
+            f"Processing EOF frame for {sender_mac} (cycle_seq={cycle_state.cycle_seq_num})"
+        )
 
         # EOF処理済みとしてマーク
         self.eof_processed[sender_mac] = current_time
@@ -515,6 +529,7 @@ class StreamingSerialProtocol(asyncio.Protocol):
 
         # EOFフレーム処理後にスリープコマンド送信
         await self._send_sleep_command_after_eof(sender_mac)
+        self.cycle_tracker.complete_cycle(sender_mac)
 
     async def _chunk_processed_callback(
         self, sender_mac: str, chunk_data: bytes, seq_num: int

--- a/server/sensor_data_reciver/protocol/streaming_handler.py
+++ b/server/sensor_data_reciver/protocol/streaming_handler.py
@@ -311,21 +311,23 @@ class StreamingSerialProtocol(asyncio.Protocol):
 
     async def _process_streaming_hash_frame(self, sender_mac: str, chunk_data: bytes, seq_num: int):
         """HASHフレーム処理（ストリーミング対応）"""
-        cycle_state = self.cycle_tracker.observe_hash(sender_mac, seq_num)
         try:
             payload_str = chunk_data[5:].decode("ascii")  # 'HASH:' をスキップ
         except UnicodeDecodeError:
             logger.warning(f"Could not decode HASH payload from {sender_mac}")
             return
 
-        logger.info(
-            f"Received HASH frame from {sender_mac} (cycle_seq={cycle_state.cycle_seq_num}): {payload_str}"
-        )
         payload_split = payload_str.split(",")
 
         if len(payload_split) < 2:
             logger.warning(f"Invalid HASH payload format: {payload_str}")
             return
+
+        cycle_state = self.cycle_tracker.observe_hash(sender_mac, seq_num)
+
+        logger.info(
+            f"Received HASH frame from {sender_mac} (cycle_seq={cycle_state.cycle_seq_num}): {payload_str}"
+        )
 
         hash_value = payload_split[0]
         volt_log_entry = payload_split[1]

--- a/server/sensor_data_reciver/protocol/streaming_handler.py
+++ b/server/sensor_data_reciver/protocol/streaming_handler.py
@@ -510,28 +510,30 @@ class StreamingSerialProtocol(asyncio.Protocol):
 
         cycle_state = self.cycle_tracker.observe_eof(sender_mac, seq_num)
 
-        logger.info(
-            f"Processing EOF frame for {sender_mac} (cycle_seq={cycle_state.cycle_seq_num})"
-        )
+        try:
+            logger.info(
+                f"Processing EOF frame for {sender_mac} (cycle_seq={cycle_state.cycle_seq_num})"
+            )
 
-        # EOF処理済みとしてマーク
-        self.eof_processed[sender_mac] = current_time
+            # EOF処理済みとしてマーク
+            self.eof_processed[sender_mac] = current_time
 
-        # ストリーミング画像を完成・保存
-        final_path = await self.streaming_processor.finalize_image_stream(
-            sender_mac, self.stats
-        )
+            # ストリーミング画像を完成・保存
+            final_path = await self.streaming_processor.finalize_image_stream(
+                sender_mac, self.stats
+            )
 
-        if final_path:
-            # 統計更新
-            self.stats["received_images"] = self.stats.get("received_images", 0) + 1
-            logger.info(f"✓ Streaming image saved: {final_path}")
-        else:
-            logger.error(f"Failed to finalize streaming image for {sender_mac}")
+            if final_path:
+                # 統計更新
+                self.stats["received_images"] = self.stats.get("received_images", 0) + 1
+                logger.info(f"✓ Streaming image saved: {final_path}")
+            else:
+                logger.error(f"Failed to finalize streaming image for {sender_mac}")
 
-        # EOFフレーム処理後にスリープコマンド送信
-        await self._send_sleep_command_after_eof(sender_mac)
-        self.cycle_tracker.complete_cycle(sender_mac)
+            # EOFフレーム処理後にスリープコマンド送信
+            await self._send_sleep_command_after_eof(sender_mac)
+        finally:
+            self.cycle_tracker.complete_cycle(sender_mac)
 
     async def _chunk_processed_callback(
         self, sender_mac: str, chunk_data: bytes, seq_num: int

--- a/server/sensor_data_reciver/protocol/streaming_handler.py
+++ b/server/sensor_data_reciver/protocol/streaming_handler.py
@@ -91,6 +91,9 @@ class StreamingSerialProtocol(asyncio.Protocol):
         # タイムアウトチェックタスク
         self.timeout_check_task = None
 
+        # バッファ処理の多重実行を防ぐ
+        self._buffer_processing_lock = asyncio.Lock()
+
         logger.info("StreamingSerialProtocol initialized")
 
     def connection_made(self, transport):
@@ -121,11 +124,12 @@ class StreamingSerialProtocol(asyncio.Protocol):
 
     async def _process_buffer_async(self):
         """非同期バッファ処理"""
-        try:
-            self.cycle_tracker.prune_terminal_states()
-            await self._process_streaming_buffer()
-        except Exception as e:
-            logger.error(f"Error in async buffer processing: {e}")
+        async with self._buffer_processing_lock:
+            try:
+                self.cycle_tracker.prune_terminal_states()
+                await self._process_streaming_buffer()
+            except Exception as e:
+                logger.error(f"Error in async buffer processing: {e}")
 
     async def _process_streaming_buffer(self):
         """ストリーミング対応バッファ処理"""

--- a/server/sensor_data_reciver/protocol/streaming_handler.py
+++ b/server/sensor_data_reciver/protocol/streaming_handler.py
@@ -93,6 +93,7 @@ class StreamingSerialProtocol(asyncio.Protocol):
 
         # バッファ処理の多重実行を防ぐ
         self._buffer_processing_lock = asyncio.Lock()
+        self._buffer_processing_task = None
 
         logger.info("StreamingSerialProtocol initialized")
 
@@ -120,7 +121,10 @@ class StreamingSerialProtocol(asyncio.Protocol):
             )
 
         self.buffer.extend(data)
-        asyncio.create_task(self._process_buffer_async())
+        if not self._buffer_processing_task or self._buffer_processing_task.done():
+            self._buffer_processing_task = asyncio.create_task(
+                self._process_buffer_async()
+            )
 
     async def _process_buffer_async(self):
         """非同期バッファ処理"""
@@ -130,6 +134,12 @@ class StreamingSerialProtocol(asyncio.Protocol):
                 await self._process_streaming_buffer()
             except Exception as e:
                 logger.error(f"Error in async buffer processing: {e}")
+            finally:
+                self._buffer_processing_task = None
+                if self.buffer:
+                    self._buffer_processing_task = asyncio.create_task(
+                        self._process_buffer_async()
+                    )
 
     async def _process_streaming_buffer(self):
         """ストリーミング対応バッファ処理"""

--- a/server/sensor_data_reciver/protocol/streaming_handler.py
+++ b/server/sensor_data_reciver/protocol/streaming_handler.py
@@ -136,10 +136,6 @@ class StreamingSerialProtocol(asyncio.Protocol):
                 logger.error(f"Error in async buffer processing: {e}")
             finally:
                 self._buffer_processing_task = None
-                if self.buffer:
-                    self._buffer_processing_task = asyncio.create_task(
-                        self._process_buffer_async()
-                    )
 
     async def _process_streaming_buffer(self):
         """ストリーミング対応バッファ処理"""

--- a/server/sensor_data_reciver/protocol/streaming_handler.py
+++ b/server/sensor_data_reciver/protocol/streaming_handler.py
@@ -122,6 +122,7 @@ class StreamingSerialProtocol(asyncio.Protocol):
     async def _process_buffer_async(self):
         """非同期バッファ処理"""
         try:
+            self.cycle_tracker.prune_terminal_states()
             await self._process_streaming_buffer()
         except Exception as e:
             logger.error(f"Error in async buffer processing: {e}")
@@ -129,8 +130,6 @@ class StreamingSerialProtocol(asyncio.Protocol):
     async def _process_streaming_buffer(self):
         """ストリーミング対応バッファ処理"""
         while True:
-            self.cycle_tracker.prune_terminal_states()
-
             # フレームタイムアウトチェック
             await self._check_frame_timeout()
 

--- a/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
+++ b/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
@@ -175,6 +175,58 @@ class TestSerialProtocolIntegration:
         mock_write_sensor_data.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_eof_invalid_image_path_completes_cycle(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_sensor_data, setup_test_environment):
+        original_is_test_env = config.IS_TEST_ENV
+        config.IS_TEST_ENV = False
+        try:
+            mock_transport = MagicMock()
+            mock_protocol = MagicMock()
+            mock_transport.serial = MagicMock(port="test_port")
+            mock_serial_connection.return_value = (mock_transport, mock_protocol)
+
+            sender_mac = "01:02:03:04:05:06"
+            mac_bytes = b"\x01\x02\x03\x04\x05\x06"
+            seq_num_hash = 1
+            seq_num_eof = 2
+
+            hash_payload = b"HASH:abcdef123456,VOLT:12.3,TEMP:25.5,1678886400"
+            hash_frame = (
+                START_MARKER +
+                mac_bytes +
+                bytes([FRAME_TYPE_HASH]) +
+                seq_num_hash.to_bytes(SEQUENCE_NUM_LENGTH, byteorder="little") +
+                len(hash_payload).to_bytes(LENGTH_FIELD_BYTES, byteorder="little") +
+                hash_payload +
+                b'\x00' * CHECKSUM_LENGTH +
+                END_MARKER
+            )
+            eof_frame = (
+                START_MARKER +
+                mac_bytes +
+                bytes([FRAME_TYPE_EOF]) +
+                seq_num_eof.to_bytes(SEQUENCE_NUM_LENGTH, byteorder="little") +
+                (0).to_bytes(LENGTH_FIELD_BYTES, byteorder="little") +
+                b'' +
+                b'\x00' * CHECKSUM_LENGTH +
+                END_MARKER
+            )
+
+            loop = asyncio.get_running_loop()
+            connection_lost_future = loop.create_future()
+            image_buffers = {sender_mac: bytearray(b"abc")}
+            last_receive_time = {}
+            stats = {"received_images": 0, "total_bytes": 0, "start_time": 0}
+            protocol = SerialProtocol(connection_lost_future, image_buffers, last_receive_time, stats)
+            protocol.connection_made(mock_transport)
+
+            protocol.data_received(hash_frame)
+            protocol.data_received(eof_frame)
+
+            assert protocol.cycle_tracker.get_state(sender_mac).cycle_state == "Completed"
+        finally:
+            config.IS_TEST_ENV = original_is_test_env
+
+    @pytest.mark.asyncio
     async def test_receive_data_and_eof_frames(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_sensor_data, setup_test_environment):
         # モックオブジェクトの準備
         mock_transport = MagicMock()

--- a/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
+++ b/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import shutil
 import sys
+import logging
 import time
 from unittest.mock import MagicMock, patch
 
@@ -104,6 +105,39 @@ class TestSerialProtocolIntegration:
         assert args[0] == sender_mac  # MAC address
         assert args[1] == 12.3        # voltage
         assert args[2] == 25.5        # temperature
+
+    @pytest.mark.asyncio
+    async def test_receive_eof_without_hash_logs_cycle_warning(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_sensor_data, setup_test_environment, caplog):
+        mock_transport = MagicMock()
+        mock_protocol = MagicMock()
+        mock_transport.serial = MagicMock(port="test_port")
+        mock_serial_connection.return_value = (mock_transport, mock_protocol)
+
+        mac_bytes = b"\x01\x02\x03\x04\x05\x06"
+        seq_num = 7
+        frame_eof = (
+            START_MARKER +
+            mac_bytes +
+            bytes([FRAME_TYPE_EOF]) +
+            seq_num.to_bytes(SEQUENCE_NUM_LENGTH, byteorder="little") +
+            (0).to_bytes(LENGTH_FIELD_BYTES, byteorder="little") +
+            b"" +
+            b'\x00' * CHECKSUM_LENGTH +
+            END_MARKER
+        )
+
+        loop = asyncio.get_running_loop()
+        connection_lost_future = loop.create_future()
+        image_buffers = {}
+        last_receive_time = {}
+        stats = {"received_images": 0, "total_bytes": 0, "start_time": 0}
+        protocol = SerialProtocol(connection_lost_future, image_buffers, last_receive_time, stats)
+        protocol.connection_made(mock_transport)
+
+        with caplog.at_level(logging.WARNING):
+            protocol.data_received(frame_eof)
+
+        assert "EOF received but HASH was not received" in caplog.text
 
     @pytest.mark.asyncio
     async def test_receive_data_and_eof_frames(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_sensor_data, setup_test_environment):

--- a/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
+++ b/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
@@ -353,3 +353,31 @@ class TestSerialProtocolIntegration:
         protocol.process_buffer()
 
         assert len(prune_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_cycle_pruning_uses_monotonic_time(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_sensor_data, setup_test_environment):
+        mock_transport = MagicMock()
+        mock_protocol = MagicMock()
+        mock_transport.serial = MagicMock(port="test_port")
+        mock_serial_connection.return_value = (mock_transport, mock_protocol)
+
+        loop = asyncio.get_running_loop()
+        connection_lost_future = loop.create_future()
+        image_buffers = {}
+        last_receive_time = {}
+        stats = {"received_images": 0, "total_bytes": 0, "start_time": 0}
+        protocol = SerialProtocol(connection_lost_future, image_buffers, last_receive_time, stats)
+        protocol.connection_made(mock_transport)
+
+        prune_calls = []
+
+        def fake_prune_terminal_states(*args, **kwargs):
+            prune_calls.append(kwargs.get("now"))
+            return 0
+
+        protocol.cycle_tracker.prune_terminal_states = fake_prune_terminal_states
+
+        with patch("protocol.serial_handler.time.monotonic", return_value=123.456):
+            protocol._prune_cycle_states_if_due(now=None, min_interval_seconds=0.0)
+
+        assert prune_calls == [123.456]

--- a/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
+++ b/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
@@ -325,3 +325,31 @@ class TestSerialProtocolIntegration:
         # バッファがクリアされたか確認
         assert sender_mac not in protocol.image_buffers
         assert sender_mac not in protocol.last_receive_time
+
+    @pytest.mark.asyncio
+    async def test_cycle_pruning_is_rate_limited(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_sensor_data, setup_test_environment):
+        mock_transport = MagicMock()
+        mock_protocol = MagicMock()
+        mock_transport.serial = MagicMock(port="test_port")
+        mock_serial_connection.return_value = (mock_transport, mock_protocol)
+
+        loop = asyncio.get_running_loop()
+        connection_lost_future = loop.create_future()
+        image_buffers = {}
+        last_receive_time = {}
+        stats = {"received_images": 0, "total_bytes": 0, "start_time": 0}
+        protocol = SerialProtocol(connection_lost_future, image_buffers, last_receive_time, stats)
+        protocol.connection_made(mock_transport)
+
+        prune_calls = []
+
+        def fake_prune_terminal_states(*args, **kwargs):
+            prune_calls.append((args, kwargs))
+            return 0
+
+        protocol.cycle_tracker.prune_terminal_states = fake_prune_terminal_states
+
+        protocol.process_buffer()
+        protocol.process_buffer()
+
+        assert len(prune_calls) == 1

--- a/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
+++ b/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
@@ -137,7 +137,42 @@ class TestSerialProtocolIntegration:
         with caplog.at_level(logging.WARNING):
             protocol.data_received(frame_eof)
 
-        assert "EOF received but HASH was not received" in caplog.text
+        assert "EOF received before DATA/HASH" in caplog.text
+        assert caplog.text.count("EOF received before DATA/HASH") == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_hash_payload_does_not_mark_cycle_received(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_sensor_data, setup_test_environment):
+        mock_transport = MagicMock()
+        mock_protocol = MagicMock()
+        mock_transport.serial = MagicMock(port="test_port")
+        mock_serial_connection.return_value = (mock_transport, mock_protocol)
+
+        mac_bytes = b"\x01\x02\x03\x04\x05\x06"
+        seq_num = 8
+        payload_bytes = b"HASH:broken"
+        frame_bytes = (
+            START_MARKER +
+            mac_bytes +
+            bytes([FRAME_TYPE_HASH]) +
+            seq_num.to_bytes(SEQUENCE_NUM_LENGTH, byteorder="little") +
+            len(payload_bytes).to_bytes(LENGTH_FIELD_BYTES, byteorder="little") +
+            payload_bytes +
+            b'\x00' * CHECKSUM_LENGTH +
+            END_MARKER
+        )
+
+        loop = asyncio.get_running_loop()
+        connection_lost_future = loop.create_future()
+        image_buffers = {}
+        last_receive_time = {}
+        stats = {"received_images": 0, "total_bytes": 0, "start_time": 0}
+        protocol = SerialProtocol(connection_lost_future, image_buffers, last_receive_time, stats)
+        protocol.connection_made(mock_transport)
+
+        protocol.data_received(frame_bytes)
+
+        assert protocol.cycle_tracker.get_state("01:02:03:04:05:06") is None
+        mock_write_sensor_data.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_receive_data_and_eof_frames(self, mock_save_image, mock_image, mock_influx_client, mock_serial_connection, mock_write_sensor_data, setup_test_environment):

--- a/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
+++ b/server/sensor_data_reciver/tests/integration/test_serial_protocol.py
@@ -348,6 +348,7 @@ class TestSerialProtocolIntegration:
             return 0
 
         protocol.cycle_tracker.prune_terminal_states = fake_prune_terminal_states
+        protocol._last_cycle_prune_at = time.monotonic() - 120
 
         protocol.process_buffer()
         protocol.process_buffer()

--- a/server/sensor_data_reciver/tests/unit/test_cycle_tracker.py
+++ b/server/sensor_data_reciver/tests/unit/test_cycle_tracker.py
@@ -34,7 +34,7 @@ class TestCycleTracker(unittest.TestCase):
         self.assertIsNotNone(state)
         self.assertEqual(state.cycle_state, "Completed")
 
-    def test_eof_without_hash_emits_warning(self):
+    def test_eof_without_data_emits_single_warning(self):
         tracker = CycleTracker()
         sender_mac = "aa:bb:cc:dd:ee:ff"
 
@@ -42,10 +42,27 @@ class TestCycleTracker(unittest.TestCase):
             state = tracker.observe_eof(sender_mac, 21, now=1.0)
 
         self.assertTrue(
-            any("EOF received but HASH was not received" in message for message in logs.output)
+            any("EOF received before DATA/HASH" in message for message in logs.output)
         )
+        self.assertEqual(len(logs.output), 1)
         self.assertEqual(state.cycle_state, "EofReceived")
         self.assertEqual(state.cycle_seq_num, 21)
+        self.assertTrue(state.warning_emitted)
+
+    def test_eof_after_data_without_hash_emits_missing_hash_warning(self):
+        tracker = CycleTracker()
+        sender_mac = "aa:bb:cc:dd:ee:01"
+
+        tracker.observe_data(sender_mac, 20, now=0.5)
+
+        with self.assertLogs("protocol.cycle_tracker", level="WARNING") as logs:
+            state = tracker.observe_eof(sender_mac, 21, now=1.0)
+
+        self.assertTrue(
+            any("EOF received but HASH was not received" in message for message in logs.output)
+        )
+        self.assertEqual(len(logs.output), 1)
+        self.assertEqual(state.cycle_state, "EofReceived")
         self.assertTrue(state.warning_emitted)
 
     def test_new_cycle_starts_after_completion(self):

--- a/server/sensor_data_reciver/tests/unit/test_cycle_tracker.py
+++ b/server/sensor_data_reciver/tests/unit/test_cycle_tracker.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import unittest
+
+# テスト対象へのパスを通す
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+from protocol.cycle_tracker import CycleTracker
+
+
+class TestCycleTracker(unittest.TestCase):
+    def test_cycle_transitions_and_completion(self):
+        tracker = CycleTracker()
+        sender_mac = "01:02:03:04:05:06"
+
+        state = tracker.observe_data(sender_mac, 10, now=1.0)
+        self.assertEqual(state.cycle_state, "ReceivingData")
+        self.assertEqual(state.cycle_seq_num, 10)
+        self.assertFalse(state.hash_received)
+
+        state = tracker.observe_hash(sender_mac, 11, now=2.0)
+        self.assertEqual(state.cycle_state, "HashReceived")
+        self.assertEqual(state.cycle_seq_num, 11)
+        self.assertTrue(state.hash_received)
+
+        state = tracker.observe_eof(sender_mac, 12, now=3.0)
+        self.assertEqual(state.cycle_state, "EofReceived")
+        self.assertEqual(state.cycle_seq_num, 11)
+        self.assertTrue(state.eof_received)
+        self.assertFalse(state.warning_emitted)
+
+        state = tracker.complete_cycle(sender_mac, now=4.0)
+        self.assertIsNotNone(state)
+        self.assertEqual(state.cycle_state, "Completed")
+
+    def test_eof_without_hash_emits_warning(self):
+        tracker = CycleTracker()
+        sender_mac = "aa:bb:cc:dd:ee:ff"
+
+        with self.assertLogs("protocol.cycle_tracker", level="WARNING") as logs:
+            state = tracker.observe_eof(sender_mac, 21, now=1.0)
+
+        self.assertTrue(
+            any("EOF received but HASH was not received" in message for message in logs.output)
+        )
+        self.assertEqual(state.cycle_state, "EofReceived")
+        self.assertEqual(state.cycle_seq_num, 21)
+        self.assertTrue(state.warning_emitted)
+
+    def test_new_cycle_starts_after_completion(self):
+        tracker = CycleTracker()
+        sender_mac = "11:22:33:44:55:66"
+
+        first = tracker.observe_eof(sender_mac, 30, now=1.0)
+        tracker.complete_cycle(sender_mac, now=2.0)
+
+        second = tracker.observe_data(sender_mac, 31, now=3.0)
+
+        self.assertEqual(first.cycle_id + 1, second.cycle_id)
+        self.assertEqual(second.cycle_state, "ReceivingData")
+        self.assertEqual(second.cycle_seq_num, 31)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/sensor_data_reciver/tests/unit/test_cycle_tracker.py
+++ b/server/sensor_data_reciver/tests/unit/test_cycle_tracker.py
@@ -78,6 +78,18 @@ class TestCycleTracker(unittest.TestCase):
         self.assertEqual(second.cycle_state, "ReceivingData")
         self.assertEqual(second.cycle_seq_num, 31)
 
+    def test_prune_terminal_states_removes_old_completed_cycles(self):
+        tracker = CycleTracker()
+        sender_mac = "22:33:44:55:66:77"
+
+        tracker.observe_data(sender_mac, 40, now=1.0)
+        tracker.complete_cycle(sender_mac, now=2.0)
+
+        removed = tracker.prune_terminal_states(retention_seconds=1.0, now=4.0)
+
+        self.assertEqual(removed, 1)
+        self.assertIsNone(tracker.get_state(sender_mac))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
+++ b/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
@@ -213,5 +213,16 @@ class TestStreamingHandler(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(create_task.call_count, 1)
         self.assertEqual(self.protocol.buffer, bytearray(b"abcdef"))
 
+    async def test_process_buffer_async_does_not_self_reschedule(self):
+        """_process_buffer_async が自分自身を再スケジュールしないことをテスト"""
+        self.protocol.buffer.extend(b"partial")
+        self.protocol._process_streaming_buffer = AsyncMock()
+
+        with patch("protocol.streaming_handler.asyncio.create_task") as create_task:
+            await self.protocol._process_buffer_async()
+
+        create_task.assert_not_called()
+        self.assertIsNone(self.protocol._buffer_processing_task)
+
 if __name__ == '__main__':
     unittest.main()

--- a/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
+++ b/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
@@ -1,6 +1,6 @@
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import sys
 import os
 
@@ -196,6 +196,22 @@ class TestStreamingHandler(unittest.IsolatedAsyncioTestCase):
         release_first.set()
         await asyncio.gather(task1, task2)
         self.assertEqual(entered, [1, 2])
+
+    async def test_data_received_coalesces_buffer_tasks(self):
+        """data_received が buffer processing task を増殖させないことをテスト"""
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+
+        def fake_create_task(coro):
+            coro.close()
+            return mock_task
+
+        with patch("protocol.streaming_handler.asyncio.create_task", side_effect=fake_create_task) as create_task:
+            self.protocol.data_received(b"abc")
+            self.protocol.data_received(b"def")
+
+        self.assertEqual(create_task.call_count, 1)
+        self.assertEqual(self.protocol.buffer, bytearray(b"abcdef"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
+++ b/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
@@ -143,5 +143,22 @@ class TestStreamingHandler(unittest.IsolatedAsyncioTestCase):
         # 2. process_chunk が呼び出される（フォールバック）
         self.protocol.streaming_processor.process_chunk.assert_called_once()
 
+    async def test_eof_without_hash_emits_cycle_warning(self):
+        """HASHなしEOFでサイクル警告が出ることをテスト"""
+        sender_mac = "01:02:03:04:05:06"
+        seq_num = 103
+
+        self.protocol.streaming_processor.finalize_image_stream = AsyncMock(return_value=None)
+        self.protocol._send_sleep_command_after_eof = AsyncMock()
+
+        with self.assertLogs("protocol.cycle_tracker", level="WARNING") as logs:
+            await self.protocol._process_streaming_eof_frame(sender_mac, seq_num)
+
+        self.assertTrue(
+            any("EOF received but HASH was not received" in message for message in logs.output)
+        )
+        self.assertEqual(self.protocol.cycle_tracker.get_state(sender_mac).cycle_state, "Completed")
+        self.protocol._send_sleep_command_after_eof.assert_awaited_once_with(sender_mac)
+
 if __name__ == '__main__':
     unittest.main()

--- a/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
+++ b/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
@@ -171,5 +171,31 @@ class TestStreamingHandler(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(self.protocol.cycle_tracker.get_state(sender_mac))
 
+    async def test_buffer_processing_is_serialized(self):
+        """複数の buffer processing task が同時に実行されないことをテスト"""
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+        entered = []
+
+        async def fake_process_streaming_buffer():
+            entered.append(len(entered) + 1)
+            first_entered.set()
+            if len(entered) == 1:
+                await release_first.wait()
+
+        self.protocol._process_streaming_buffer = fake_process_streaming_buffer
+
+        task1 = asyncio.create_task(self.protocol._process_buffer_async())
+        await first_entered.wait()
+
+        task2 = asyncio.create_task(self.protocol._process_buffer_async())
+        await asyncio.sleep(0)
+
+        self.assertEqual(entered, [1])
+
+        release_first.set()
+        await asyncio.gather(task1, task2)
+        self.assertEqual(entered, [1, 2])
+
 if __name__ == '__main__':
     unittest.main()

--- a/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
+++ b/server/sensor_data_reciver/tests/unit/test_streaming_handler.py
@@ -155,10 +155,21 @@ class TestStreamingHandler(unittest.IsolatedAsyncioTestCase):
             await self.protocol._process_streaming_eof_frame(sender_mac, seq_num)
 
         self.assertTrue(
-            any("EOF received but HASH was not received" in message for message in logs.output)
+            any("EOF received before DATA/HASH" in message for message in logs.output)
         )
+        self.assertEqual(len(logs.output), 1)
         self.assertEqual(self.protocol.cycle_tracker.get_state(sender_mac).cycle_state, "Completed")
         self.protocol._send_sleep_command_after_eof.assert_awaited_once_with(sender_mac)
+
+    async def test_invalid_hash_payload_does_not_mark_cycle_received(self):
+        """無効なHASHペイロードでcycle状態が汚染されないことをテスト"""
+        sender_mac = "01:02:03:04:05:06"
+        seq_num = 104
+        chunk_data = b"HASH:broken"
+
+        await self.protocol._process_streaming_hash_frame(sender_mac, chunk_data, seq_num)
+
+        self.assertIsNone(self.protocol.cycle_tracker.get_state(sender_mac))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Phase1 of the HASH reliability work.

What changed:
- Added a shared per-sender cycle tracker for DATA / HASH / EOF
- Wired the tracker into both serial and streaming handlers
- Emit a warning when EOF arrives without a HASH for the same cycle
- Added focused unit and integration tests
- Updated GitHub Actions workflow dependencies to Node 24-compatible versions to address the GitHub Actions deprecation warning

Verification:
- `uv run pytest` in `server/sensor_data_reciver` (88 passed)
