### PR TITLE
fix(gateway): fix ESP-NOW frame handling for m5stack_unit_cam and temp sensor

### DIFF
--- a/server/usb_cdc_receiver/src/esp_now/frame.rs
+++ b/server/usb_cdc_receiver/src/esp_now/frame.rs
@@ -299,14 +299,22 @@ pub fn detect_frame_type(data: &[u8]) -> FrameType {
     if data.len() == 4 && data == b"EOF!" {
         return FrameType::Eof;
     }
-    
+
     // HASH判定: "HASH:"で始まる場合
     if data.len() > 5 && data.starts_with(b"HASH:") {
         return FrameType::Hash;
     }
-    
+
     // それ以外はデータフレーム
     FrameType::Data
+}
+
+/// ESP-NOW ペイロードが既にバイナリフレーム形式かどうかを判定する
+///
+/// START_MARKER (`0xFACEAABB`) で始まる場合、m5stack_unit_cam 等が
+/// 自前でフレーム化したペイロードと判断し、再ラップせずそのまま転送する。
+pub fn is_preframed(data: &[u8]) -> bool {
+    data.len() >= MARKER_LEN && data[..MARKER_LEN] == START_MARKER.to_be_bytes()
 }
 
 #[cfg(test)]
@@ -352,5 +360,33 @@ mod tests {
         assert_eq!(detect_frame_type(b"EOF!"), FrameType::Eof);
         assert_eq!(detect_frame_type(b"HASH:12345"), FrameType::Hash);
         assert_eq!(detect_frame_type(b"normal data"), FrameType::Data);
+    }
+
+    #[test]
+    fn test_is_preframed_with_start_marker() {
+        // START_MARKER (0xFACEAABB) で始まるペイロードは preframed と判定される
+        let mut data = vec![0xFA, 0xCE, 0xAA, 0xBB];
+        data.extend_from_slice(b"rest of frame");
+        assert!(is_preframed(&data));
+    }
+
+    #[test]
+    fn test_is_preframed_with_text_payload() {
+        // テキストペイロードは preframed でない
+        assert!(!is_preframed(b"HASH:0000,VOLT:100,TEMP:25.0"));
+        assert!(!is_preframed(b"EOF!"));
+    }
+
+    #[test]
+    fn test_is_preframed_too_short() {
+        // 4 バイト未満は preframed でない
+        assert!(!is_preframed(&[0xFA, 0xCE, 0xAA]));
+        assert!(!is_preframed(&[]));
+    }
+
+    #[test]
+    fn test_is_preframed_exact_marker_only() {
+        // マーカーちょうど 4 バイトでも判定できる
+        assert!(is_preframed(&[0xFA, 0xCE, 0xAA, 0xBB]));
     }
 }

--- a/server/usb_cdc_receiver/src/esp_now/receiver.rs
+++ b/server/usb_cdc_receiver/src/esp_now/receiver.rs
@@ -1,4 +1,4 @@
-use crate::esp_now::frame::{create_frame, detect_frame_type};
+use crate::esp_now::frame::{create_frame, detect_frame_type, is_preframed};
 use crate::esp_now::FrameType;
 use crate::mac_address::format_mac_address;
 use crate::queue::ReceivedData;
@@ -89,33 +89,45 @@ where
     // データスライスの取得
     let data_slice = unsafe { slice::from_raw_parts(data, data_len as usize) };
 
-    // フレームタイプの検出
-    let frame_type = detect_frame_type(data_slice);
-    let is_eof = frame_type == FrameType::Eof;
-    let is_hash = frame_type == FrameType::Hash;
+    // フレーム化 or パススルー判定
+    //
+    // ESP-NOW ペイロードが既に START_MARKER (0xFACEAABB) で始まるバイナリフレームの場合
+    // (例: m5stack_unit_cam が自前でフレーム化して送信)、再ラップせずそのまま USB CDC に転送する。
+    // 再ラップすると外側フレームの DATA ペイロードにフレーム構造体が入り込み、
+    // サーバー側で生 JPEG データとして解釈されて画像が破損する。
+    //
+    // テキスト形式 ("HASH:...", "EOF!") は従来どおりバイナリフレームに包んで転送する。
+    let (framed_data, drop_label, is_critical_eof) = if is_preframed(data_slice) {
+        debug!(
+            "ESP-NOW CB [{}]: Pre-framed binary payload ({} bytes), forwarding without re-wrapping.",
+            mac_str, data_len
+        );
+        (data_slice.to_vec(), "preframed", false)
+    } else {
+        let frame_type = detect_frame_type(data_slice);
+        let is_eof = frame_type == FrameType::Eof;
+        let is_hash = frame_type == FrameType::Hash;
 
-    // 特殊フレーム（EOFやHASH）のログ出力
-    if is_eof {
-        warn!("ESP-NOW CB [{}]: Received EOF marker (b\"EOF!\").", mac_str);
-    } else if is_hash {
-        warn!("ESP-NOW CB [{}]: Received HASH marker.", mac_str);
-    }
+        if is_eof {
+            warn!("ESP-NOW CB [{}]: Received EOF marker (b\"EOF!\").", mac_str);
+        } else if is_hash {
+            warn!("ESP-NOW CB [{}]: Received HASH marker.", mac_str);
+        }
 
-    // シーケンス番号の取得（EOFまたはHASHでリセット）
-    let seq_num = get_sequence_number(mac_array, is_eof || is_hash);
+        let seq_num = get_sequence_number(mac_array, is_eof || is_hash);
+        let framed = create_frame(mac_array, data_slice, frame_type, seq_num);
 
-    // データをフレーム化
-    let framed_data = create_frame(mac_array, data_slice, frame_type, seq_num);
+        debug!(
+            "ESP-NOW CB [{}]: Received chunk ({} bytes, type={}, seq={}). Framed: {} bytes.",
+            mac_str,
+            data_len,
+            frame_type.as_str(),
+            seq_num,
+            framed.len()
+        );
 
-    // デバッグログ
-    debug!(
-        "ESP-NOW CB [{}]: Received chunk ({} bytes, type={}, seq={}). Framed: {} bytes.",
-        mac_str,
-        data_len,
-        frame_type.as_str(),
-        seq_num,
-        framed_data.len()
-    );
+        (framed, frame_type.as_str(), is_eof)
+    };
 
     // フレーム化されたデータをキューに追加
     let received_data = ReceivedData {
@@ -127,16 +139,11 @@ where
     let success = producer(received_data);
 
     if !success {
-        // キューへの追加が失敗した場合
         warn!(
-            "ESP-NOW CB [{}]: Data queue full! Dropping {} frame (seq={}).",
-            mac_str,
-            frame_type.as_str(),
-            seq_num
+            "ESP-NOW CB [{}]: Data queue full! Dropping {} frame.",
+            mac_str, drop_label
         );
-
-        // EOFフレームが落とされた場合は特に重要なので強調
-        if is_eof {
+        if is_critical_eof {
             error!(
                 "ESP-NOW CB [{}]: CRITICAL! EOF frame dropped due to queue full!",
                 mac_str

--- a/server/usb_cdc_receiver/src/main.rs
+++ b/server/usb_cdc_receiver/src/main.rs
@@ -24,6 +24,7 @@ use log::{debug, error, info, warn};
 use mac_address::format_mac_address;
 use sleep_command_queue::{init_sleep_command_queue, enqueue_sleep_command, process_sleep_command_queue};
 use usb::cdc::UsbCdc;
+use usb::UsbInterface;
 
 // PythonからのコマンドやESP-NOWのデータを橋渡しするグローバルコントローラー
 // NOTE: A global `STREAMING_CONTROLLER` was previously defined here to bridge

--- a/server/usb_cdc_receiver/src/sleep_command_queue.rs
+++ b/server/usb_cdc_receiver/src/sleep_command_queue.rs
@@ -2,7 +2,6 @@
 /// 
 /// ESP-NOWの競合を回避するため、スリープコマンドを順序化して送信します。
 
-use esp_idf_svc::hal::delay::FreeRtos;
 use heapless::Deque;
 use log::{info, warn, error};
 use crate::esp_now::sender::EspNowSender;

--- a/server/usb_cdc_receiver/src/streaming/controller.rs
+++ b/server/usb_cdc_receiver/src/streaming/controller.rs
@@ -13,6 +13,7 @@
 use super::{StreamingError, StreamingResult, StreamingStatistics};
 use super::device_manager::{DeviceStreamManager, ProcessedFrame, StreamManagerConfig};
 use crate::usb::cdc::UsbCdc;
+use crate::usb::UsbInterface;
 use crate::esp_now::sender::EspNowSender;
 use crate::esp_now::{AckMessage, MessageType, AckStatus};
 use log::{debug, info, warn, error};


### PR DESCRIPTION
## Summary

- `is_preframed()` を `frame.rs` に追加し、ESP-NOW ペイロードが既にバイナリフレーム形式 (`0xFACEAABB` 開始) かどうかを判定する
- `receiver.rs` で `is_preframed()` による分岐を実装:
  - **m5stack_unit_cam** (自前でバイナリフレーム化): 再ラップせずそのまま USB CDC に転送
  - **温度センサー** (テキスト形式 `HASH:...`): 従来どおり LE バイナリフレームに包んで転送
- `streaming/controller.rs` と `main.rs` に不足していた `use crate::usb::UsbInterface` を追加
- `sleep_command_queue.rs` の未使用 `FreeRtos` import を削除

## Root Cause

ゲートウェイはすべての ESP-NOW ペイロードを無条件にバイナリフレームで再ラップしていた。m5stack_unit_cam は自前でバイナリフレームを生成して送信するため、二重ラップになりサーバーが画像データを正常に解析できなかった。

また、`UsbInterface` トレイトが `send_frame()` / `read_command()` の呼び出し元スコープにインポートされておらず、ESP ターゲットビルドが失敗していた（ホストテストのみでは検出されない問題）。

## Test plan

- [x] `bash run_tests.sh` (ホストユニットテスト) 全件通過
- [x] `cargo build --release` (ESP32-C3 ターゲット) ビルド成功
- [x] 検証環境でゲートウェイフラッシュ後、m5stack_unit_cam の画像保存と温度センサーのデータ受信を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)