### PR TITLE
chore(deps): update esp-temp-sensor submodule and rev to PR#5 (be8e7e2)

### DIFF
--- a/devices/xiao_esp32s3_temp_sensor/Cargo.toml
+++ b/devices/xiao_esp32s3_temp_sensor/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0"
 
 # ESP32 ターゲット専用の依存 (ホストテスト時はコンパイル対象外)
 [target.'cfg(any(target_arch = "riscv32", target_arch = "xtensa"))'.dependencies]
-simple_ds18b20_temp_sensor = { git = "https://github.com/junkei-okinawa/esp-temp-sensor", rev = "74c87a2ee5933c9bc3ac2c6d58c730d909a36356" }
+simple_ds18b20_temp_sensor = { git = "https://github.com/junkei-okinawa/esp-temp-sensor", rev = "be8e7e2eb090835f15d99a1d035208c01c267dbc" }
 esp-idf-svc = "0.51.0"
 esp-idf-sys = "0.36"
 toml-cfg = "=0.2"


### PR DESCRIPTION
## Summary

- Update `sensors/esp-temp-sensor` submodule pointer: `74c87a2` → `be8e7e2` (PR#5 マージ後の main)
- Update `devices/xiao_esp32s3_temp_sensor/Cargo.toml` の `simple_ds18b20_temp_sensor` rev を同じ `be8e7e2` に bump

## What's included in be8e7e2 (esp-temp-sensor PR#5)

DS18B20 の 85°C 誤検出バグ修正:
- Dallas 1-Wire CRC-8 (`compute_crc8`) によるスクラッチパッド整合性検証
- 85.0°C POR デフォルト値の検出とリトライ（最大 3 回、パワーサイクル付き）
- エラーパスのログに `EspError` 値を含める
- バス障害時のエラー伝播改善

## Test plan

- [x] esp-temp-sensor PR#5 の CI (clippy / fmt / test) がすべて green
- [ ] XIAO ESP32-S3 に `use_deep_sleep = true` でフラッシュして 85°C スパイクが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)